### PR TITLE
Fix Windows ENOENT when spawning npx

### DIFF
--- a/packages/autoskills/installer.mjs
+++ b/packages/autoskills/installer.mjs
@@ -2,13 +2,17 @@ import { spawn } from "node:child_process";
 import { parseSkillPath } from "./lib.mjs";
 import { dim, green, cyan, red, HIDE_CURSOR, SHOW_CURSOR, SPINNER } from "./colors.mjs";
 
+export function getNpxCommand(platform = process.platform) {
+  return platform === "win32" ? "npx.cmd" : "npx";
+}
+
 export function installSkill(skillPath) {
   const { repo, skillName } = parseSkillPath(skillPath);
   const args = ["-y", "skills", "add", repo];
   if (skillName) args.push("--skill", skillName);
   args.push("-y");
   return new Promise((resolve) => {
-    const child = spawn("npx", args, {
+    const child = spawn(getNpxCommand(), args, {
       stdio: ["pipe", "pipe", "pipe"],
     });
 

--- a/packages/autoskills/tests/installer.test.mjs
+++ b/packages/autoskills/tests/installer.test.mjs
@@ -1,0 +1,14 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { getNpxCommand } from "../installer.mjs";
+
+describe("installer", () => {
+  it("uses npx.cmd on Windows", () => {
+    assert.equal(getNpxCommand("win32"), "npx.cmd");
+  });
+
+  it("uses npx on non-Windows platforms", () => {
+    assert.equal(getNpxCommand("linux"), "npx");
+    assert.equal(getNpxCommand("darwin"), "npx");
+  });
+});


### PR DESCRIPTION
## Summary
- fix Windows compatibility when installing skills by selecting `npx.cmd` on `win32` instead of always using `npx`
- keep current behavior unchanged on Linux/macOS (`npx`)
- add installer unit tests to validate command selection per platform

## Test plan
- [x] `node --test tests/*.test.mjs` in `packages/autoskills`
- [x] verified `child_process.spawn('npx.cmd', ['--version'])` works on Windows
- [x] smoke-tested CLI with `node index.mjs --dry-run --yes`

Fixes #1
