### PR TITLE
feat(autoskills): detect Kotlin Multiplatform and Android via Gradle

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ npx autoskills
 ## How it works
 
 1. Run `npx autoskills` in your project root
-2. Your `package.json` and config files are scanned to detect technologies
+2. Your `package.json`, Gradle files, and config files are scanned to detect technologies
 3. The best matching AI agent skills are installed via [skills.sh](https://skills.sh)
 
 That's it. No config needed.
@@ -36,7 +36,7 @@ That's it. No config needed.
 
 ## Supported technologies
 
-React · Next.js · Vue · Nuxt · Pinia · Svelte · Angular · Astro · Tailwind CSS · shadcn/ui · TypeScript · Supabase · Neon · Playwright · Expo · React Native · Remotion · Better Auth · Turborepo · Vite · Azure · Vercel · Vercel AI SDK · ElevenLabs · Cloudflare · Durable Objects · Cloudflare Agents · Cloudflare AI · AWS · SwiftUI · oxlint · GSAP · Node.js · Express · Bun · Deno
+React · Next.js · Vue · Nuxt · Pinia · Svelte · Angular · Astro · Tailwind CSS · shadcn/ui · TypeScript · Supabase · Neon · Playwright · Expo · React Native · Kotlin Multiplatform · Android · Remotion · Better Auth · Turborepo · Vite · Azure · Vercel · Vercel AI SDK · ElevenLabs · Cloudflare · Durable Objects · Cloudflare Agents · Cloudflare AI · AWS · SwiftUI · oxlint · GSAP · Node.js · Express · Bun · Deno
 
 ## Requirements
 

--- a/packages/autoskills/README.md
+++ b/packages/autoskills/README.md
@@ -46,7 +46,7 @@ npx autoskills --dry-run
 
 ## Supported Technologies
 
-`autoskills` detects **37+ technologies** from your `package.json`, lockfiles, and config files:
+`autoskills` detects **39+ technologies** from your `package.json`, lockfiles, Gradle files, and config files:
 
 ### Frameworks & Libraries
 
@@ -61,6 +61,8 @@ npx autoskills --dry-run
 | Astro | `astro` package or `astro.config.*` |
 | Expo | `expo` package |
 | React Native | `react-native` package |
+| Kotlin Multiplatform | Gradle with KMP plugin: `kotlin("multiplatform")`, `org.jetbrains.kotlin.multiplatform`, or `kotlin-multiplatform` in `gradle/libs.versions.toml` |
+| Android | Gradle with `com.android.application`, `com.android.library`, or `com.android.kotlin.multiplatform.library` |
 | Remotion | `remotion`, `@remotion/cli` |
 | GSAP | `gsap` package |
 | Express | `express` package |

--- a/packages/autoskills/lib.mjs
+++ b/packages/autoskills/lib.mjs
@@ -163,6 +163,51 @@ export const SKILLS_MAP = [
     skills: ["sleekdotdesign/agent-skills/sleek-design-mobile-apps"],
   },
   {
+    id: "kotlin-multiplatform",
+    name: "Kotlin Multiplatform",
+    detect: {
+      configFileContent: {
+        scanGradleLayout: true,
+        patterns: [
+          'kotlin("multiplatform")',
+          "org.jetbrains.kotlin.multiplatform",
+          'id("org.jetbrains.kotlin.multiplatform")',
+          "kotlin-multiplatform",
+        ],
+      },
+    },
+    skills: [
+      "Kotlin/kotlin-agent-skills/kotlin-tooling-cocoapods-spm-migration",
+      "Kotlin/kotlin-agent-skills/kotlin-tooling-agp9-migration",
+    ],
+  },
+  {
+    id: "android",
+    name: "Android",
+    detect: {
+      configFileContent: {
+        scanGradleLayout: true,
+        patterns: [
+          "com.android.application",
+          "com.android.library",
+          'id("com.android.application")',
+          'id("com.android.library")',
+          "com.android.kotlin.multiplatform.library",
+        ],
+      },
+    },
+    skills: [
+      "krutikJain/android-agent-skills/android-kotlin-core",
+      "krutikJain/android-agent-skills/android-compose-foundations",
+      "krutikJain/android-agent-skills/android-architecture-clean",
+      "krutikJain/android-agent-skills/android-di-hilt",
+      "krutikJain/android-agent-skills/android-gradle-build-logic",
+      "krutikJain/android-agent-skills/android-coroutines-flow",
+      "krutikJain/android-agent-skills/android-networking-retrofit-okhttp",
+      "krutikJain/android-agent-skills/android-testing-unit",
+    ],
+  },
+  {
     id: "remotion",
     name: "Remotion",
     detect: {
@@ -498,6 +543,41 @@ const SCAN_SKIP_DIRS = new Set([
   "coverage", ".turbo", "var",
 ]);
 
+const GRADLE_SCAN_ROOT_FILES = [
+  "build.gradle.kts",
+  "build.gradle",
+  "settings.gradle.kts",
+  "settings.gradle",
+  "gradle/libs.versions.toml",
+];
+
+function gradleLayoutCandidatePaths(projectDir) {
+  const candidates = [];
+  for (const f of GRADLE_SCAN_ROOT_FILES) {
+    candidates.push(join(projectDir, f));
+  }
+  let entries;
+  try {
+    entries = readdirSync(projectDir, { withFileTypes: true });
+  } catch {
+    entries = [];
+  }
+  for (const e of entries) {
+    if (!e.isDirectory() || e.name.startsWith(".") || SCAN_SKIP_DIRS.has(e.name)) continue;
+    for (const g of ["build.gradle.kts", "build.gradle"]) {
+      candidates.push(join(projectDir, e.name, g));
+    }
+  }
+  return candidates;
+}
+
+function resolveConfigFileContentPaths(projectDir, config) {
+  if (config.scanGradleLayout) {
+    return gradleLayoutCandidatePaths(projectDir);
+  }
+  return (config.files || []).map((f) => join(projectDir, f));
+}
+
 export function hasWebFrontendFiles(projectDir, maxDepth = 3) {
   function scan(dir, depth) {
     let entries;
@@ -565,16 +645,18 @@ export function detectTechnologies(projectDir) {
     }
 
     if (!found && tech.detect.configFileContent) {
-      const { files, patterns } = tech.detect.configFileContent;
-      for (const f of files) {
-        const filePath = join(projectDir, f);
-        if (existsSync(filePath)) {
-          try {
-            const content = readFileSync(filePath, "utf-8");
-            found = patterns.some((p) => content.includes(p));
-            if (found) break;
-          } catch {}
-        }
+      const cfg = tech.detect.configFileContent;
+      const paths = resolveConfigFileContentPaths(projectDir, cfg);
+      const { patterns } = cfg;
+      for (const filePath of paths) {
+        if (!existsSync(filePath)) continue;
+        try {
+          const content = readFileSync(filePath, "utf-8");
+          if (patterns.some((p) => content.includes(p))) {
+            found = true;
+            break;
+          }
+        } catch {}
       }
     }
 

--- a/packages/autoskills/package.json
+++ b/packages/autoskills/package.json
@@ -1,6 +1,6 @@
 {
   "name": "autoskills",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Auto-detect and install the best AI agent skills for your project",
   "keywords": [
     "agent",

--- a/packages/autoskills/tests/detect.test.mjs
+++ b/packages/autoskills/tests/detect.test.mjs
@@ -1,6 +1,6 @@
 import { describe, it, beforeEach, afterEach } from "node:test";
 import assert from "node:assert/strict";
-import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { mkdtempSync, writeFileSync, rmSync, mkdirSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { getAllPackageNames, readPackageJson, detectTechnologies, detectCombos } from "../lib.mjs";
@@ -242,6 +242,59 @@ describe("detectTechnologies", () => {
     const { combos } = detectTechnologies(tmpDir);
     const comboIds = combos.map((c) => c.id);
     assert.ok(!comboIds.includes("expo-tailwind"));
+  });
+
+  it("detects Kotlin Multiplatform from root build.gradle.kts", () => {
+    writeFileSync(join(tmpDir, "package.json"), JSON.stringify({}));
+    writeFileSync(
+      join(tmpDir, "build.gradle.kts"),
+      'plugins { kotlin("multiplatform") version "2.0.0" }',
+    );
+    const { detected } = detectTechnologies(tmpDir);
+    assert.ok(detected.some((t) => t.id === "kotlin-multiplatform"));
+  });
+
+  it("detects Kotlin Multiplatform from nested module build.gradle.kts", () => {
+    writeFileSync(join(tmpDir, "package.json"), JSON.stringify({}));
+    const mod = join(tmpDir, "composeApp");
+    mkdirSync(mod, { recursive: true });
+    writeFileSync(
+      join(mod, "build.gradle.kts"),
+      'plugins { id("org.jetbrains.kotlin.multiplatform") }',
+    );
+    const { detected } = detectTechnologies(tmpDir);
+    assert.ok(detected.some((t) => t.id === "kotlin-multiplatform"));
+  });
+
+  it("detects Android from nested app build.gradle.kts", () => {
+    writeFileSync(join(tmpDir, "package.json"), JSON.stringify({}));
+    const app = join(tmpDir, "app");
+    mkdirSync(app, { recursive: true });
+    writeFileSync(
+      join(app, "build.gradle.kts"),
+      'plugins { id("com.android.application") }',
+    );
+    const { detected } = detectTechnologies(tmpDir);
+    assert.ok(detected.some((t) => t.id === "android"));
+  });
+
+  it("detects KMP and Android together for typical mobile KMP layout", () => {
+    writeFileSync(join(tmpDir, "package.json"), JSON.stringify({}));
+    const mod = join(tmpDir, "composeApp");
+    mkdirSync(mod, { recursive: true });
+    writeFileSync(
+      join(mod, "build.gradle.kts"),
+      `
+plugins {
+  kotlin("multiplatform")
+  id("com.android.application")
+}
+`,
+    );
+    const { detected } = detectTechnologies(tmpDir);
+    const ids = detected.map((t) => t.id);
+    assert.ok(ids.includes("kotlin-multiplatform"));
+    assert.ok(ids.includes("android"));
   });
 });
 


### PR DESCRIPTION
Detecta proyectos Kotlin Multiplatform y Android leyendo archivos Gradle en la raíz del repo y en un nivel de subcarpetas (build.gradle[.kts], settings.gradle[.kts], gradle/libs.versions.toml).
Reutiliza el mecanismo existente configFileContent con scanGradleLayout, sin un segundo sistema de detección solo para Gradle.
Propone skills de [Kotlin/kotlin-agent-skills](https://github.com/Kotlin/kotlin-agent-skills) (KMP) y una selección de [krutikJain/android-agent-skills](https://github.com/krutikJain/android-agent-skills) (Android).
Actualiza README (raíz y paquete) y sube la versión del paquete a 0.1.6.