### PR TITLE
Enhance agent installation support in autoskills CLI

### DIFF
--- a/packages/autoskills/index.mjs
+++ b/packages/autoskills/index.mjs
@@ -20,11 +20,20 @@ process.on("SIGINT", () => {
 
 function parseArgs() {
   const args = process.argv.slice(2);
+  const agents = [];
+  const agentIdx = args.findIndex((a) => a === "-a" || a === "--agent");
+  if (agentIdx !== -1) {
+    for (let i = agentIdx + 1; i < args.length; i++) {
+      if (args[i].startsWith("-")) break;
+      agents.push(args[i]);
+    }
+  }
   return {
     autoYes: args.includes("-y") || args.includes("--yes"),
     dryRun: args.includes("--dry-run"),
     verbose: args.includes("--verbose") || args.includes("-v"),
     help: args.includes("--help") || args.includes("-h"),
+    agents,
   };
 }
 
@@ -33,14 +42,16 @@ function showHelp() {
   ${bold("autoskills")} — Auto-install the best AI skills for your project
 
   ${bold("Usage:")}
-    npx autoskills            Detect & install skills
-    npx autoskills ${dim("-y")}        Skip confirmation
-    npx autoskills ${dim("--dry-run")} Show what would be installed
+    npx autoskills                   Detect & install skills
+    npx autoskills ${dim("-y")}                   Skip confirmation
+    npx autoskills ${dim("--dry-run")}            Show what would be installed
+    npx autoskills ${dim("-a cursor claude-code")} Install for specific IDEs only
 
   ${bold("Options:")}
     -y, --yes       Skip confirmation prompt
     --dry-run       Show skills without installing
     -v, --verbose   Show error details on failure
+    -a, --agent     Install for specific IDEs only (e.g. cursor, claude-code)
     -h, --help      Show this help message
 `);
 }
@@ -181,7 +192,7 @@ async function selectSkills(skills, autoYes) {
 // ── Main ─────────────────────────────────────────────────────
 
 async function main() {
-  const { autoYes, dryRun, verbose, help } = parseArgs();
+  const { autoYes, dryRun, verbose, help, agents } = parseArgs();
 
   if (help) {
     showHelp();
@@ -231,10 +242,13 @@ async function main() {
   }
 
   console.log(cyan("   ▸ ") + bold("Installing skills..."));
+  if (agents.length > 0) {
+    console.log(dim(`   Agents: ${agents.join(", ")}`));
+  }
   console.log();
 
   const startTime = Date.now();
-  const { installed, failed, errors } = await installAll(selectedSkills);
+  const { installed, failed, errors } = await installAll(selectedSkills, agents);
   const elapsed = Date.now() - startTime;
 
   if (process.stdout.isTTY) {

--- a/packages/autoskills/installer.mjs
+++ b/packages/autoskills/installer.mjs
@@ -6,11 +6,17 @@ export function getNpxCommand(platform = process.platform) {
   return platform === "win32" ? "npx.cmd" : "npx";
 }
 
-export function installSkill(skillPath) {
+export function buildInstallArgs(skillPath, agents = []) {
   const { repo, skillName } = parseSkillPath(skillPath);
   const args = ["-y", "skills", "add", repo];
   if (skillName) args.push("--skill", skillName);
   args.push("-y");
+  if (agents.length > 0) args.push("-a", ...agents);
+  return args;
+}
+
+export function installSkill(skillPath, agents = []) {
+  const args = buildInstallArgs(skillPath, agents);
   return new Promise((resolve) => {
     const child = spawn(getNpxCommand(), args, {
       stdio: ["pipe", "pipe", "pipe"],
@@ -38,8 +44,8 @@ export function installSkill(skillPath) {
  * Parallel installer with animated spinners and live status.
  * Falls back to sequential output for non-TTY environments.
  */
-export async function installAll(skills) {
-  if (!process.stdout.isTTY) return installAllSimple(skills);
+export async function installAll(skills, agents = []) {
+  if (!process.stdout.isTTY) return installAllSimple(skills, agents);
 
   const CONCURRENCY = 3;
   const total = skills.length;
@@ -98,7 +104,7 @@ export async function installAll(skills) {
       state.status = "installing";
       render();
 
-      const result = await installSkill(state.skill);
+      const result = await installSkill(state.skill, agents);
 
       if (result.success) {
         state.status = "success";
@@ -123,13 +129,13 @@ export async function installAll(skills) {
   return { installed, failed, errors };
 }
 
-async function installAllSimple(skills) {
+async function installAllSimple(skills, agents = []) {
   let installed = 0;
   let failed = 0;
   const errors = [];
 
   for (const { skill } of skills) {
-    const result = await installSkill(skill);
+    const result = await installSkill(skill, agents);
 
     if (result.success) {
       console.log(green(`   ✔ ${skill}`));

--- a/packages/autoskills/tests/cli.test.mjs
+++ b/packages/autoskills/tests/cli.test.mjs
@@ -22,6 +22,7 @@ describe("CLI", () => {
     assert.ok(output.includes("autoskills"));
     assert.ok(output.includes("--dry-run"));
     assert.ok(output.includes("--yes"));
+    assert.ok(output.includes("--agent"));
   });
 
   it("shows help with -h", () => {

--- a/packages/autoskills/tests/installer.test.mjs
+++ b/packages/autoskills/tests/installer.test.mjs
@@ -1,6 +1,6 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { getNpxCommand } from "../installer.mjs";
+import { getNpxCommand, buildInstallArgs } from "../installer.mjs";
 
 describe("installer", () => {
   it("uses npx.cmd on Windows", () => {
@@ -10,5 +10,33 @@ describe("installer", () => {
   it("uses npx on non-Windows platforms", () => {
     assert.equal(getNpxCommand("linux"), "npx");
     assert.equal(getNpxCommand("darwin"), "npx");
+  });
+});
+
+describe("buildInstallArgs", () => {
+  it("builds args without -a when no agents specified", () => {
+    const args = buildInstallArgs("owner/repo/my-skill");
+    assert.deepEqual(args, ["-y", "skills", "add", "owner/repo", "--skill", "my-skill", "-y"]);
+    assert.ok(!args.includes("-a"));
+  });
+
+  it("appends -a with a single agent", () => {
+    const args = buildInstallArgs("owner/repo/my-skill", ["cursor"]);
+    assert.deepEqual(args, ["-y", "skills", "add", "owner/repo", "--skill", "my-skill", "-y", "-a", "cursor"]);
+  });
+
+  it("appends -a with multiple agents", () => {
+    const args = buildInstallArgs("owner/repo/my-skill", ["cursor", "claude-code"]);
+    assert.deepEqual(args, ["-y", "skills", "add", "owner/repo", "--skill", "my-skill", "-y", "-a", "cursor", "claude-code"]);
+  });
+
+  it("passes through wildcard agent", () => {
+    const args = buildInstallArgs("owner/repo/my-skill", ["*"]);
+    assert.deepEqual(args, ["-y", "skills", "add", "owner/repo", "--skill", "my-skill", "-y", "-a", "*"]);
+  });
+
+  it("handles skill path without skill name", () => {
+    const args = buildInstallArgs("owner/repo", ["cursor"]);
+    assert.deepEqual(args, ["-y", "skills", "add", "owner/repo", "-y", "-a", "cursor"]);
   });
 });


### PR DESCRIPTION
  ---                                                                                                                                                                                                                     
  feat: add -a/--agent flag to filter skill installation by IDE                                                                                                                                                           
                                                                                                                                                                                                                                                                                          
  ## Problem
                                                                                                                                                                                                                          
  When running `autoskills`, skills are installed for every IDE the `skills` CLI                                                                                                                                          
  detects or supports — creating folders like `.cursor/skills/`, `.claude/skills/`,
  `.windsurf/skills/`, and `.kiro/skills/` even if those IDEs are not installed or                                                                                                                                        
  not used in the project.                                                                                                                                                                                                
                                                                                                                                                                                                                          
  ## Solution                                                                                                                                                                                                             
                                                                  
  Add a `-a`/`--agent` flag that passes agent names directly to the underlying                                                                                                                                            
  `npx skills add -a` call. The `skills` CLI already supports this flag — autoskills
  was just never forwarding it.                                                                                                                                                                                           
                                                                  
  ## Changes                                                                                                                                                                                                              
                                                                  
  - **`index.mjs`** — parses `-a`/`--agent` from CLI args, shows selected agents                                                                                                                                          
    in output, threads them through to `installAll`
  - **`installer.mjs`** — extracts `buildInstallArgs()` as a pure function, adds                                                                                                                                          
    `agents` param to `installSkill`, `installAll`, and `installAllSimple`                                                                                                                                                
  - **Tests** — 5 new unit tests for `buildInstallArgs`, updated help test                                                                                                                                                
                                                                                                                                                                                                                          
  ## Usage                                                                                                                                                                                                                
                                                                                                                                                                                                                          
  ```bash                                                         
  # Install only for Cursor
  npx autoskills -a cursor
                                                                                                                                                                                                                          
  # Install only for Cursor and Claude Code, skip confirmation                                                                                                                                                            
  npx autoskills -a cursor claude-code -y                                                                                                                                                                                 
                                                                                                                                                                                                                          
  # Install for all agents regardless of detection                
  npx autoskills -a '*'
                                                                                                                                                                                                                          
  No breaking changes — omitting the flag preserves existing behavior.  