### PR TITLE
Fix shadcn + Tailwind SKILL combo installation

### DIFF
--- a/packages/autoskills/lib.mjs
+++ b/packages/autoskills/lib.mjs
@@ -442,7 +442,7 @@ export const COMBO_SKILLS_MAP = [
     id: "tailwind-shadcn",
     name: "Tailwind CSS + shadcn/ui",
     requires: ["tailwind", "shadcn"],
-    skills: ["jezweb/claude-skills/tailwind-v4-shadcn"],
+    skills: ["secondsky/claude-skills/tailwind-v4-shadcn"],
   },
   {
     id: "gsap-react",


### PR DESCRIPTION
La SKILL tailwind-v4-shadcn ya no existe en el repositorio original del que se había extraído aunque todavía aparece en el listado de [skills.sh](https://skills.sh/?q=tailwind-v4-shadcn)

- **Error a replicar**: `npx skills add https://github.com/jezweb/claude-skills --skill tailwind-v4-shadcn`
- **Repositorio de la SKILL antigua**: https://github.com/jezweb/claude-skills

- **Stack trace de la instalación desde autoskills**: 

```cmd
✔ vercel-labs/next-skills/next-cache-components
   ✔ vercel-labs/next-skills/next-upgrade
   ✔ giuseppe-trisciuoglio/developer-kit/tailwind-css-patterns
   ✔ shadcn/ui/shadcn
   ✔ wshobson/agents/typescript-advanced-types
   ✔ better-auth/skills/better-auth-best-practices
   ✔ better-auth/skills/email-and-password-best-practices
   ✔ better-auth/skills/organization-best-practices
   ✔ better-auth/skills/two-factor-authentication-best-practices
   ✔ wshobson/agents/nodejs-backend-patterns
   ✔ sickn33/antigravity-awesome-skills/nodejs-best-practices
   ✘ jezweb/claude-skills/tailwind-v4-shadcn — failed
   ✔ anthropics/skills/frontend-design
   ✔ addyosmani/web-quality-skills/accessibility
   ✔ addyosmani/web-quality-skills/seo

   Done: 17 installed, 1 failed in 13.2s.

   Errors:
     ✘ jezweb/claude-skills/tailwind-v4-shadcn
       │    - wordpress-elementor
       │
       │    - wordpress-setup
       │
       │    - social-media-posts

   Enjoyed autoskills? Consider sponsoring → https://github.com/sponsors/midudev
```

closes #7 