### PR TITLE
feat: auto-detect installed agents for skill installation

### DIFF
--- a/packages/autoskills/index.mjs
+++ b/packages/autoskills/index.mjs
@@ -4,7 +4,7 @@ import { resolve, dirname, join } from "node:path";
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 
-import { detectTechnologies, collectSkills } from "./lib.mjs";
+import { detectTechnologies, collectSkills, detectAgents } from "./lib.mjs";
 import { bold, dim, green, yellow, cyan, magenta, red, pink, SHOW_CURSOR } from "./colors.mjs";
 import { printBanner, multiSelect, formatTime } from "./ui.mjs";
 import { installAll } from "./installer.mjs";
@@ -91,7 +91,10 @@ function printDetected(detected, combos, isFrontend) {
     };
 
     for (let i = 0; i < allTech.length; i += COLS) {
-      const row = allTech.slice(i, i + COLS).map(formatTech).join("");
+      const row = allTech
+        .slice(i, i + COLS)
+        .map(formatTech)
+        .join("");
       console.log(`     ${row}`);
     }
 
@@ -170,7 +173,9 @@ function printSummary({ installed, failed, errors, elapsed, verbose }) {
     }
   }
   console.log();
-  console.log(pink("   Enjoyed autoskills? Consider sponsoring → https://github.com/sponsors/midudev"));
+  console.log(
+    pink("   Enjoyed autoskills? Consider sponsoring → https://github.com/sponsors/midudev"),
+  );
   console.log();
 }
 
@@ -191,9 +196,7 @@ async function selectSkills(skills, autoYes) {
     return skills;
   }
 
-  console.log(
-    cyan("   ▸ ") + bold(`Select skills to install `) + dim(`(${skills.length} found)`),
-  );
+  console.log(cyan("   ▸ ") + bold(`Select skills to install `) + dim(`(${skills.length} found)`));
   console.log();
 
   const selected = await multiSelect(skills, {
@@ -244,6 +247,7 @@ async function main() {
   printDetected(detected, combos, isFrontend);
 
   const skills = collectSkills(detected, isFrontend, combos);
+  const resolvedAgents = agents.length > 0 ? agents : detectAgents();
 
   if (skills.length === 0) {
     console.log(yellow("   No skills available for your stack yet."));
@@ -254,6 +258,7 @@ async function main() {
 
   if (dryRun) {
     printSkillsList(skills);
+    console.log(dim(`   Agents: ${resolvedAgents.join(", ")}`));
     console.log(dim("   --dry-run: nothing was installed."));
     console.log();
     process.exit(0);
@@ -269,13 +274,11 @@ async function main() {
   }
 
   console.log(cyan("   ▸ ") + bold("Installing skills..."));
-  if (agents.length > 0) {
-    console.log(dim(`   Agents: ${agents.join(", ")}`));
-  }
+  console.log(dim(`   Agents: ${resolvedAgents.join(", ")}`));
   console.log();
 
   const startTime = Date.now();
-  const { installed, failed, errors } = await installAll(selectedSkills, agents);
+  const { installed, failed, errors } = await installAll(selectedSkills, resolvedAgents);
   const elapsed = Date.now() - startTime;
 
   if (process.stdout.isTTY) {

--- a/packages/autoskills/lib.mjs
+++ b/packages/autoskills/lib.mjs
@@ -1,5 +1,6 @@
 import { readFileSync, existsSync, readdirSync } from "node:fs";
 import { join, resolve } from "node:path";
+import { homedir } from "node:os";
 
 export {
   SKILLS_MAP,
@@ -7,6 +8,7 @@ export {
   FRONTEND_PACKAGES,
   FRONTEND_BONUS_SKILLS,
   WEB_FRONTEND_EXTENSIONS,
+  AGENT_FOLDER_MAP,
 } from "./skills-map.mjs";
 
 import {
@@ -15,14 +17,26 @@ import {
   FRONTEND_PACKAGES,
   FRONTEND_BONUS_SKILLS,
   WEB_FRONTEND_EXTENSIONS,
+  AGENT_FOLDER_MAP,
 } from "./skills-map.mjs";
 
 // ── Internal Constants ───────────────────────────────────────
 
 const SCAN_SKIP_DIRS = new Set([
-  "node_modules", ".git", "vendor", ".next", "dist", "build",
-  ".output", ".nuxt", ".svelte-kit", "__pycache__", ".cache",
-  "coverage", ".turbo", "var",
+  "node_modules",
+  ".git",
+  "vendor",
+  ".next",
+  "dist",
+  "build",
+  ".output",
+  ".nuxt",
+  ".svelte-kit",
+  "__pycache__",
+  ".cache",
+  "coverage",
+  ".turbo",
+  "var",
 ]);
 
 const GRADLE_SCAN_ROOT_FILES = [
@@ -134,7 +148,12 @@ function parsePnpmWorkspaceYaml(content) {
     }
     if (inPackages) {
       if (line.startsWith("- ")) {
-        patterns.push(line.slice(2).trim().replace(/^['"]|['"]$/g, ""));
+        patterns.push(
+          line
+            .slice(2)
+            .trim()
+            .replace(/^['"]|['"]$/g, ""),
+        );
       } else if (line !== "" && !line.startsWith("#")) {
         break;
       }
@@ -164,7 +183,8 @@ function expandWorkspacePatterns(projectDir, patterns) {
         continue;
       }
       for (const entry of entries) {
-        if (!entry.isDirectory() || SCAN_SKIP_DIRS.has(entry.name) || entry.name.startsWith(".")) continue;
+        if (!entry.isDirectory() || SCAN_SKIP_DIRS.has(entry.name) || entry.name.startsWith("."))
+          continue;
         const wsDir = join(parent, entry.name);
         if (existsSync(join(wsDir, "package.json"))) {
           dirs.push(wsDir);
@@ -339,6 +359,27 @@ export function detectTechnologies(projectDir) {
  */
 export function detectCombos(detectedIds) {
   return COMBO_SKILLS_MAP.filter((combo) => combo.requires.every((id) => detectedIds.includes(id)));
+}
+
+// ── Agent Detection ─────────────────────────────────────────
+
+/**
+ * Detects which AI coding agents are installed by checking for `skills/` subdirectories
+ * inside known agent folders in the user's home directory.
+ * Always includes `"universal"` as the first entry.
+ * @param {string} [home=os.homedir()] - Home directory to scan (injectable for testing).
+ * @returns {string[]} Agent identifiers suitable for `npx skills add -a ...`.
+ */
+export function detectAgents(home = homedir()) {
+  const agents = ["universal"];
+
+  for (const [folder, agentName] of Object.entries(AGENT_FOLDER_MAP)) {
+    if (existsSync(join(home, folder, "skills"))) {
+      agents.push(agentName);
+    }
+  }
+
+  return agents;
 }
 
 // ── Helpers ──────────────────────────────────────────────────

--- a/packages/autoskills/skills-map.mjs
+++ b/packages/autoskills/skills-map.mjs
@@ -477,15 +477,10 @@ export const SKILLS_MAP = [
       ],
       configFileContent: {
         files: ["pom.xml"],
-        patterns: [
-          "spring-boot-starter",
-          "org.springframework.boot",
-        ],
+        patterns: ["spring-boot-starter", "org.springframework.boot"],
       },
     },
-    skills: [
-      "github/awesome-copilot/java-springboot",
-    ],
+    skills: ["github/awesome-copilot/java-springboot"],
   },
 ];
 
@@ -579,9 +574,43 @@ export const FRONTEND_BONUS_SKILLS = [
   "addyosmani/web-quality-skills/seo",
 ];
 
+// ── Agent Folder Map ─────────────────────────────────────────
+
+/**
+ * Maps well-known agent home directory folder names to their `skills` CLI agent identifiers.
+ * Only the most common agents are included; `.agents` (universal) is handled separately.
+ */
+export const AGENT_FOLDER_MAP = {
+  ".claude": "claude-code",
+  ".cursor": "cursor",
+  ".cline": "cline",
+  ".codex": "codex",
+  ".antigravity": "antigravity",
+  ".augment": "augment",
+  ".copilot": "github-copilot",
+  ".gemini": "gemini-cli",
+  ".junie": "junie",
+  ".amp": "amp",
+  ".supermaven": "supermaven",
+  ".codebuddy": "codebuddy",
+  ".continue": "continue",
+};
+
 export const WEB_FRONTEND_EXTENSIONS = new Set([
-  ".html", ".htm",
-  ".css", ".scss", ".sass", ".less",
-  ".vue", ".svelte", ".jsx", ".tsx",
-  ".twig", ".tpl", ".ejs", ".hbs", ".pug", ".njk",
+  ".html",
+  ".htm",
+  ".css",
+  ".scss",
+  ".sass",
+  ".less",
+  ".vue",
+  ".svelte",
+  ".jsx",
+  ".tsx",
+  ".twig",
+  ".tpl",
+  ".ejs",
+  ".hbs",
+  ".pug",
+  ".njk",
 ]);

--- a/packages/autoskills/tests/cli.test.mjs
+++ b/packages/autoskills/tests/cli.test.mjs
@@ -424,10 +424,7 @@ describe("CLI", () => {
 
     it("detects WordPress from style.css theme header", () => {
       writeFileSync(join(tmpDir, "package.json"), JSON.stringify({}));
-      writeFileSync(
-        join(tmpDir, "style.css"),
-        "/*\nTheme Name: My Theme\nAuthor: Test\n*/",
-      );
+      writeFileSync(join(tmpDir, "style.css"), "/*\nTheme Name: My Theme\nAuthor: Test\n*/");
 
       const output = run(["--dry-run"], tmpDir);
 
@@ -449,7 +446,10 @@ describe("CLI", () => {
 
     it("detects web frontend from .tpl files (PrestaShop)", () => {
       mkdirSync(join(tmpDir, "themes", "classic", "templates"), { recursive: true });
-      writeFileSync(join(tmpDir, "themes", "classic", "templates", "index.tpl"), "{block name='content'}{/block}");
+      writeFileSync(
+        join(tmpDir, "themes", "classic", "templates", "index.tpl"),
+        "{block name='content'}{/block}",
+      );
 
       const output = run(["--dry-run"], tmpDir);
 
@@ -556,6 +556,34 @@ describe("CLI", () => {
       assert.ok(output.includes("frontend-design"));
       assert.ok(output.includes("accessibility"));
       assert.ok(output.includes("seo"));
+    });
+
+    it("shows auto-detected agents in dry-run output", () => {
+      writeFileSync(
+        join(tmpDir, "package.json"),
+        JSON.stringify({
+          dependencies: { react: "^19" },
+        }),
+      );
+
+      const output = run(["--dry-run"], tmpDir);
+
+      assert.ok(output.includes("Agents:"));
+      assert.ok(output.includes("universal"));
+    });
+
+    it("shows user-specified agents instead of auto-detected", () => {
+      writeFileSync(
+        join(tmpDir, "package.json"),
+        JSON.stringify({
+          dependencies: { react: "^19" },
+        }),
+      );
+
+      const output = run(["--dry-run", "-a", "cursor"], tmpDir);
+
+      assert.ok(output.includes("Agents: cursor"));
+      assert.ok(!output.includes("universal"));
     });
   });
 });

--- a/packages/autoskills/tests/detect-agents.test.mjs
+++ b/packages/autoskills/tests/detect-agents.test.mjs
@@ -1,0 +1,70 @@
+import { describe, it, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { detectAgents, AGENT_FOLDER_MAP } from "../lib.mjs";
+
+describe("detectAgents", () => {
+  let tmpHome;
+
+  beforeEach(() => {
+    tmpHome = mkdtempSync(join(tmpdir(), "autoskills-agents-"));
+  });
+
+  afterEach(() => {
+    rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  it("always includes universal as first entry", () => {
+    const agents = detectAgents(tmpHome);
+    assert.deepEqual(agents, ["universal"]);
+  });
+
+  it("detects claude-code from .claude/skills", () => {
+    mkdirSync(join(tmpHome, ".claude", "skills"), { recursive: true });
+    const agents = detectAgents(tmpHome);
+    assert.ok(agents.includes("universal"));
+    assert.ok(agents.includes("claude-code"));
+  });
+
+  it("detects cursor from .cursor/skills", () => {
+    mkdirSync(join(tmpHome, ".cursor", "skills"), { recursive: true });
+    const agents = detectAgents(tmpHome);
+    assert.ok(agents.includes("cursor"));
+  });
+
+  it("detects multiple agents", () => {
+    mkdirSync(join(tmpHome, ".claude", "skills"), { recursive: true });
+    mkdirSync(join(tmpHome, ".cline", "skills"), { recursive: true });
+    mkdirSync(join(tmpHome, ".codex", "skills"), { recursive: true });
+    const agents = detectAgents(tmpHome);
+    assert.equal(agents[0], "universal");
+    assert.ok(agents.includes("claude-code"));
+    assert.ok(agents.includes("cline"));
+    assert.ok(agents.includes("codex"));
+    assert.equal(agents.length, 4);
+  });
+
+  it("ignores agent folders without skills subdirectory", () => {
+    mkdirSync(join(tmpHome, ".claude"), { recursive: true });
+    mkdirSync(join(tmpHome, ".cursor"), { recursive: true });
+    const agents = detectAgents(tmpHome);
+    assert.deepEqual(agents, ["universal"]);
+  });
+
+  it("ignores unknown folders with skills subdirectory", () => {
+    mkdirSync(join(tmpHome, ".unknown-editor", "skills"), { recursive: true });
+    const agents = detectAgents(tmpHome);
+    assert.deepEqual(agents, ["universal"]);
+  });
+
+  it("detects all mapped agents when present", () => {
+    for (const folder of Object.keys(AGENT_FOLDER_MAP)) {
+      mkdirSync(join(tmpHome, folder, "skills"), { recursive: true });
+    }
+    const agents = detectAgents(tmpHome);
+    assert.equal(agents[0], "universal");
+    assert.equal(agents.length, 1 + Object.keys(AGENT_FOLDER_MAP).length);
+  });
+});


### PR DESCRIPTION
## Summary
- When no `-a` flag is provided, autoskills now scans `~/.<agent>/skills` directories to auto-detect installed agents (Claude Code, Cursor, Cline, etc.)
- Always includes `universal` as baseline, plus any detected agent-specific targets
- Prevents `skills add` from hanging on its interactive agent prompt when stdio is piped

## Problem

Without `-a`, `npx skills add` launches an interactive prompt to select agents. Since autoskills calls it via `child_process.spawn` with piped stdio, this prompt hangs indefinitely. Users had to always pass `-a` manually, which defeats the "zero-config" philosophy.

## Solution

Added `detectAgents()` that scans the user's home directory for known agent folders with a `skills/` subdirectory. This determines which agents the user actually has installed, and passes them automatically via `-a universal <detected-agents>`.

## Changes
- **`skills-map.mjs`**: Added `AGENT_FOLDER_MAP` (13 known agents) — follows existing pattern of data maps in this file
- **`lib.mjs`**: Added `detectAgents(home?)` function with injectable home dir for testing (DI principle)
- **`index.mjs`**: Resolves agents once via `detectAgents()` when user omits `-a`; displays agents in both dry-run and install output
- **`tests/detect-agents.test.mjs`**: 7 unit tests covering all detection edge cases
- **`tests/cli.test.mjs`**: 2 outside-in integration tests verifying CLI output with/without `-a`

## Upstream PR

This issue also exists in the `skills` CLI itself — when multiple agents are detected, it shows an interactive prompt that hangs with piped stdio. Submitted a fix upstream:

- **vercel-labs/skills#816** — auto-select detected agents instead of interactive prompt
- Related upstream issues: vercel-labs/skills#793, vercel-labs/skills#178, vercel-labs/skills#304

## Test plan
- [x] `npm test` — 141 tests pass (139 existing + 2 new CLI tests)
- [x] `node --test tests/detect-agents.test.mjs` — 7 new unit tests pass
- [x] `npx oxlint` — 0 errors
- [x] `npx oxfmt --check` — all changed files formatted
- [x] `npx autoskills --dry-run` — shows `Agents: universal, claude-code, cline, codex`
- [x] `npx autoskills --dry-run -a cursor` — shows `Agents: cursor` (user override)