### PR TITLE
feat: add optional skills for Node.js and frontend bonus detection

### DIFF
--- a/packages/autoskills/README.md
+++ b/packages/autoskills/README.md
@@ -130,7 +130,7 @@ npx autoskills --dry-run
 
 ### Web Frontend Detection
 
-Even without a framework, `autoskills` scans your file tree for web frontend signals (`.html`, `.css`, `.scss`, `.vue`, `.svelte`, `.jsx`, `.tsx`, `.twig`, `.blade.php`, etc.) and installs skills for frontend design, accessibility, and SEO.
+Even without a framework, `autoskills` scans your file tree for web frontend signals (`.html`, `.css`, `.scss`, `.vue`, `.svelte`, `.jsx`, `.tsx`, `.twig`, `.blade.php`, etc.) and installs skills for frontend design, interface design, accessibility, SEO, and UI-focused debugging/brainstorming.
 
 ## Combo Detection
 

--- a/packages/autoskills/skills-map.mjs
+++ b/packages/autoskills/skills-map.mjs
@@ -416,6 +416,9 @@ export const SKILLS_MAP = [
     skills: [
       "wshobson/agents/nodejs-backend-patterns",
       "sickn33/antigravity-awesome-skills/nodejs-best-practices",
+      "wshobson/agents/api-design-principles",
+      "wshobson/agents/error-handling-patterns",
+      "obra/superpowers/systematic-debugging",
     ],
   },
   {
@@ -665,6 +668,9 @@ export const FRONTEND_BONUS_SKILLS = [
   "anthropics/skills/frontend-design",
   "addyosmani/web-quality-skills/accessibility",
   "addyosmani/web-quality-skills/seo",
+  "dammyjay93/interface-design/interface-design",
+  "obra/superpowers/brainstorming",
+  "obra/superpowers/systematic-debugging",
 ];
 
 // ── Agent Folder Map ─────────────────────────────────────────


### PR DESCRIPTION
## What was changed
This PR updates the skills routing map to include additional optional skills in two existing detection paths:
- **Node.js detection** (`id: "node"`) now also installs:
  - `wshobson/agents/api-design-principles`
  - `wshobson/agents/error-handling-patterns`
  - `obra/superpowers/systematic-debugging`
- **Frontend bonus detection** (`FRONTEND_BONUS_SKILLS`) now also installs:
  - `dammyjay93/interface-design/interface-design`
  - `obra/superpowers/brainstorming`
  - `obra/superpowers/systematic-debugging`
- **Docs update** in `packages/autoskills/README.md` to reflect that frontend bonus now covers interface design and UI-focused debugging/brainstorming.
## Why
These skills are useful in many projects but are most relevant when scoped by project type:
- Node.js projects benefit from API design and error-handling guidance.
- Frontend projects benefit from interface-focused design support and ideation/debugging aids.
This keeps installation automatic while improving skill relevance.
## Scope
- No detection logic refactor.
- No new technology entries.
- Only skill list extensions for existing Node.js and frontend bonus paths.
## Validation
- Ran: `node --test "tests/*.test.mjs"` in `packages/autoskills`
- Result: **158 passed, 0 failed**