### PR TITLE
feat: add Kiro agent support

### DIFF
--- a/packages/autoskills/skills-map.mjs
+++ b/packages/autoskills/skills-map.mjs
@@ -226,7 +226,21 @@ export const SKILLS_MAP = [
     id: "clerk",
     name: "Clerk",
     detect: {
-      packages: ["@clerk/nextjs", "@clerk/remix", "@clerk/astro", "@clerk/express", "@clerk/fastify", "@clerk/nuxt", "@clerk/vue", "@clerk/react", "@clerk/expo", "@clerk/tanstack-react-start", "@clerk/react-router", "@clerk/chrome-extension", "@clerk/backend"],
+      packages: [
+        "@clerk/nextjs",
+        "@clerk/remix",
+        "@clerk/astro",
+        "@clerk/express",
+        "@clerk/fastify",
+        "@clerk/nuxt",
+        "@clerk/vue",
+        "@clerk/react",
+        "@clerk/expo",
+        "@clerk/tanstack-react-start",
+        "@clerk/react-router",
+        "@clerk/chrome-extension",
+        "@clerk/backend",
+      ],
       packagePatterns: [/^@clerk\//],
     },
     skills: [
@@ -687,6 +701,7 @@ export const AGENT_FOLDER_MAP = {
   ".supermaven": "supermaven",
   ".codebuddy": "codebuddy",
   ".continue": "continue",
+  ".kiro": "kiro",
 };
 
 export const WEB_FRONTEND_EXTENSIONS = new Set([

--- a/packages/autoskills/tests/detect-agents.test.mjs
+++ b/packages/autoskills/tests/detect-agents.test.mjs
@@ -34,6 +34,12 @@ describe("detectAgents", () => {
     assert.ok(agents.includes("cursor"));
   });
 
+  it("detects kiro from .kiro/skills", () => {
+    mkdirSync(join(tmpHome, ".kiro", "skills"), { recursive: true });
+    const agents = detectAgents(tmpHome);
+    assert.ok(agents.includes("kiro"));
+  });
+
   it("detects multiple agents", () => {
     mkdirSync(join(tmpHome, ".claude", "skills"), { recursive: true });
     mkdirSync(join(tmpHome, ".cline", "skills"), { recursive: true });


### PR DESCRIPTION
Adds Kiro (https://kiro.dev) to the `AGENT_FOLDER_MAP` so autoskills can detect
and install skills for Kiro users.

Kiro stores skills in `~/.kiro/skills/`, which matches the existing detection
pattern used by autoskills.

## Changes

- Added `".kiro": "kiro"` to `AGENT_FOLDER_MAP` in `skills-map.mjs`
- Added test case for Kiro agent detection in `detect-agents.test.mjs`

All 159 tests pass.

## Note on formatting

This PR also includes a minor formatting fix in the Clerk `packages` array
(single long line → multi-line). This was a pre-existing issue on `main` that
causes `oxfmt --check` to fail in CI. Included here to keep CI green, since
the file was already being modified. No logic changes.
