### PR TITLE
feat: add Three.js and @react-three/fiber.

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ That's it. No config needed.
 
 ## Supported technologies
 
-React · Next.js · Vue · Nuxt · Pinia · Svelte · Angular · Astro · Tailwind CSS · shadcn/ui · TypeScript · Supabase · Neon · Playwright · Expo · React Native · Kotlin Multiplatform · Android · Remotion · Better Auth · Clerk · Turborepo · Vite · Azure · Vercel · Vercel AI SDK · ElevenLabs · Cloudflare · Durable Objects · Cloudflare Agents · Cloudflare AI · AWS · SwiftUI · oxlint · GSAP · Node.js · Express · Bun · Deno · Prisma · Stripe · Hono · Vitest · Drizzle ORM · NestJS · Tauri · Spring Boot
+React · Next.js · Vue · Nuxt · Pinia · Svelte · Angular · Astro · Tailwind CSS · shadcn/ui · TypeScript · Supabase · Neon · Playwright · Expo · React Native · Kotlin Multiplatform · Android · Remotion · Better Auth · Clerk · Turborepo · Vite · Azure · Vercel · Vercel AI SDK · ElevenLabs · Cloudflare · Durable Objects · Cloudflare Agents · Cloudflare AI · AWS · SwiftUI · oxlint · GSAP · Three.js · Node.js · Express · Bun · Deno · Prisma · Stripe · Hono · Vitest · Drizzle ORM · NestJS · Tauri · Spring Boot
 
 ## Requirements
 

--- a/packages/autoskills/README.md
+++ b/packages/autoskills/README.md
@@ -46,7 +46,7 @@ npx autoskills --dry-run
 
 ## Supported Technologies
 
-`autoskills` detects **48+ technologies** from your `package.json`, lockfiles, Gradle files, and config files:
+`autoskills` detects **49+ technologies** from your `package.json`, lockfiles, Gradle files, and config files:
 
 ### Frameworks & Libraries
 
@@ -65,6 +65,7 @@ npx autoskills --dry-run
 | Android              | Gradle with `com.android.application`, `com.android.library`, or `com.android.kotlin.multiplatform.library`                                       |
 | Remotion             | `remotion`, `@remotion/cli`                                                                                                                       |
 | GSAP                 | `gsap` package                                                                                                                                    |
+| Three.js             | `three`, `@react-three/fiber`, `@react-three/drei`                                                                                                |
 | Express              | `express` package                                                                                                                                 |
 | Hono                 | `hono` package                                                                                                                                    |
 | NestJS               | `@nestjs/core` package                                                                                                                            |

--- a/packages/autoskills/skills-map.mjs
+++ b/packages/autoskills/skills-map.mjs
@@ -414,6 +414,33 @@ export const SKILLS_MAP = [
     ],
   },
   {
+    id: "threejs",
+    name: "Three.js",
+    detect: {
+      packages: ["three"],
+    },
+    skills: [
+      "cloudai-x/threejs-skills/threejs-animation",
+      "cloudai-x/threejs-skills/threejs-fundamentals",
+      "cloudai-x/threejs-skills/threejs-shaders",
+      "cloudai-x/threejs-skills/threejs-geometry",
+      "cloudai-x/threejs-skills/threejs-interaction",
+      "cloudai-x/threejs-skills/threejs-materials",
+      "cloudai-x/threejs-skills/threejs-postprocessing",
+      "cloudai-x/threejs-skills/threejs-lighting",
+      "cloudai-x/threejs-skills/threejs-textures",
+      "cloudai-x/threejs-skills/threejs-loaders",
+    ],
+  },
+  {
+    id: "@react-three/fiber",
+    name: "React Three Fiber",
+    detect: {
+      packages: ["@react-three/fiber"],
+    },
+    skills: [],
+  },
+  {
     id: "bun",
     name: "Bun",
     detect: {
@@ -656,6 +683,12 @@ export const COMBO_SKILLS_MAP = [
       "clerk/skills/clerk-setup",
       "clerk/skills/clerk",
     ],
+  },
+  {
+    id: "react-react-three-fiber",
+    name: "React + React Three Fiber",
+    requires: ["threejs", "react", "@react-three/fiber"],
+    skills: ["vercel-labs/json-render/react-three-fiber"],
   },
 ];
 

--- a/packages/autoskills/tests/detect.test.mjs
+++ b/packages/autoskills/tests/detect.test.mjs
@@ -171,6 +171,36 @@ describe("detectTechnologies", () => {
     assert.ok(ids.includes("tailwind"));
   });
 
+  it("detects Three.js from dependencies", () => {
+    writeFileSync(
+      join(tmpDir, "package.json"),
+      JSON.stringify({ dependencies: { three: "^0.173.0" } }),
+    );
+    const { detected } = detectTechnologies(tmpDir);
+    const ids = detected.map((t) => t.id);
+    assert.ok(ids.includes("threejs"));
+  });
+
+  it("keeps Three.js detection when React and React Three Fiber are present", () => {
+    writeFileSync(
+      join(tmpDir, "package.json"),
+      JSON.stringify({ dependencies: { three: "^0.173.0", react: "^19.0.0", "react-dom": "^19.0.0" } }),
+    );
+    const { detected } = detectTechnologies(tmpDir);
+    const ids = detected.map((t) => t.id);
+    assert.ok(ids.includes("threejs"));
+  });
+
+  it("detects React + React Three Fiber combo when Three.js is present", () => {
+    writeFileSync(
+      join(tmpDir, "package.json"),
+      JSON.stringify({ dependencies: { three: "^0.173.0", react: "^19.0.0", "@react-three/fiber": "^9.0.0" } }),
+    );
+    const { combos } = detectTechnologies(tmpDir);
+    const comboIds = combos.map((c) => c.id);
+    assert.ok(comboIds.includes("react-react-three-fiber"));
+  });
+
   it("detects shadcn/ui from components.json", () => {
     writeFileSync(join(tmpDir, "package.json"), JSON.stringify({}));
     writeFileSync(join(tmpDir, "components.json"), "{}");
@@ -725,6 +755,21 @@ describe("detectCombos", () => {
   it("detects nextjs-clerk combo", () => {
     const combos = detectCombos(["nextjs", "clerk"]);
     assert.ok(combos.some((c) => c.id === "nextjs-clerk"));
+  });
+
+  it("detects react-react-three-fiber combo", () => {
+    const combos = detectCombos(["threejs", "react", "@react-three/fiber"]);
+    assert.ok(combos.some((c) => c.id === "react-react-three-fiber"));
+  });
+
+  it("does not detect react-react-three-fiber combo without react", () => {
+    const combos = detectCombos(["threejs", "@react-three/fiber"]);
+    assert.ok(!combos.some((c) => c.id === "react-react-three-fiber"));
+  });
+
+  it("does not detect react-react-three-fiber combo without Three.js", () => {
+    const combos = detectCombos(["react", "@react-three/fiber"]);
+    assert.ok(!combos.some((c) => c.id === "react-react-three-fiber"));
   });
 
   it("does not detect nextjs-clerk combo without clerk", () => {

--- a/src/icons/threejs.svg
+++ b/src/icons/threejs.svg
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 25.0.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" id="Layer_1" x="0px" y="0px" viewBox="0 0 640 640" style="enable-background:new 0 0 640 640;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:#FFFFFF;}
+	.st1{fill:#FFFFFF;stroke:#000000;stroke-width:7;stroke-miterlimit:10;}
+	.st2{fill:none;stroke:#000000;stroke-width:7;stroke-miterlimit:10;}
+</style>
+<polyline class="st0" points="171.7,621.7 20,18.4 620,186.9 "/>
+<g>
+	<line class="st1" x1="245.8" y1="362.4" x2="283.7" y2="513.3"/>
+	<line class="st1" x1="395.5" y1="404.8" x2="245.8" y2="362.4"/>
+	<line class="st1" x1="283.7" y1="513.3" x2="395.5" y2="404.8"/>
+	<path class="st1" d="M134,470.9"/>
+	<line class="st1" x1="283.7" y1="513.3" x2="134" y2="470.9"/>
+	<path class="st1" d="M134,470.9"/>
+	<polyline class="st2" points="134,470.9 171.9,621.9 283.7,513.3  "/>
+	<line class="st1" x1="134" y1="470.9" x2="245.8" y2="362.4"/>
+	<line class="st1" x1="245.8" y1="362.4" x2="357.7" y2="253.8"/>
+	<line class="st1" x1="357.7" y1="253.8" x2="469.5" y2="145.3"/>
+	<line class="st1" x1="319.8" y1="102.9" x2="357.7" y2="253.8"/>
+	<line class="st1" x1="357.7" y1="253.8" x2="207.9" y2="211.5"/>
+	<line class="st1" x1="207.9" y1="211.5" x2="245.8" y2="362.4"/>
+	<line class="st1" x1="245.8" y1="362.4" x2="96.1" y2="320"/>
+	<line class="st1" x1="96.1" y1="320" x2="134" y2="470.9"/>
+	<line class="st1" x1="58.2" y1="169.1" x2="96.1" y2="320"/>
+	<line class="st1" x1="207.9" y1="211.5" x2="58.2" y2="169.1"/>
+	<line class="st1" x1="96.1" y1="320" x2="207.9" y2="211.5"/>
+	<line class="st1" x1="207.9" y1="211.4" x2="319.8" y2="102.9"/>
+	<line class="st1" x1="319.8" y1="102.9" x2="170" y2="60.5"/>
+	<line class="st1" x1="170" y1="60.5" x2="207.9" y2="211.4"/>
+	<polyline class="st2" points="58.2,169.1 20.3,18.1 170,60.5  "/>
+	<line class="st1" x1="58.2" y1="169.1" x2="170" y2="60.5"/>
+	<polyline class="st2" points="507.4,296.2 619.2,187.7 469.5,145.3  "/>
+	<line class="st1" x1="469.5" y1="145.3" x2="507.4" y2="296.2"/>
+	<line class="st1" x1="507.4" y1="296.2" x2="357.7" y2="253.8"/>
+	<line class="st1" x1="357.7" y1="253.8" x2="395.5" y2="404.8"/>
+	<line class="st1" x1="395.5" y1="404.8" x2="507.4" y2="296.2"/>
+	<line class="st1" x1="469.5" y1="145.3" x2="319.8" y2="102.9"/>
+</g>
+</svg>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -119,6 +119,7 @@ const popularityOrder = [
   'android',
   'java',
   'springboot',
+  'threejs'
 ];
 
 const skillsMap = [...SKILLS_MAP].sort((a: any, b: any) => {


### PR DESCRIPTION
-  Added native Three.js support with skills from `cloudai-x/threejs-skills`:
  - `threejs-animation`
  - `threejs-fundamentals`
  - `threejs-shaders`
  - `threejs-geometry`
  - `threejs-interaction`
  - `threejs-materials`
  - `threejs-postprocessing`
  - `threejs-lighting`
  - `threejs-textures`
  - `threejs-loaders`
- Implemented conditional combo behavior for React + Three:
  - If `three` is detected, Three.js skills are installed.
  - If `three` + `react` + `@react-three/fiber` are detected together, it also installs:
    - `vercel-labs/json-render/react-three-fiber`
- Update tech count from 48+ to 49+