### PR TITLE
feat: add support for deno.json and deno.jsonc in workspace

### DIFF
--- a/packages/autoskills/lib.mjs
+++ b/packages/autoskills/lib.mjs
@@ -186,13 +186,13 @@ function expandWorkspacePatterns(projectDir, patterns) {
         if (!entry.isDirectory() || SCAN_SKIP_DIRS.has(entry.name) || entry.name.startsWith("."))
           continue;
         const wsDir = join(parent, entry.name);
-        if (existsSync(join(wsDir, "package.json"))) {
+        if (existsSync(join(wsDir, "package.json")) || existsSync(join(wsDir, "deno.json")) || existsSync(join(wsDir, "deno.jsonc"))) {
           dirs.push(wsDir);
         }
       }
     } else {
       const wsDir = join(projectDir, pattern);
-      if (existsSync(join(wsDir, "package.json"))) {
+      if (existsSync(join(wsDir, "package.json")) || existsSync(join(wsDir, "deno.json")) || existsSync(join(wsDir, "deno.jsonc"))) {
         dirs.push(wsDir);
       }
     }
@@ -233,6 +233,16 @@ export function resolveWorkspaces(projectDir) {
     }
   }
 
+  const denoJson = readDenoJson(projectDir);
+  if (denoJson?.workspace) {
+    const members = Array.isArray(denoJson.workspace) ? denoJson.workspace : [];
+    if (members.length > 0) {
+      return expandWorkspacePatterns(projectDir, members).filter(
+        (d) => resolve(d) !== resolve(projectDir),
+      );
+    }
+  }
+
   return [];
 }
 
@@ -251,6 +261,44 @@ export function readPackageJson(dir) {
   } catch {
     return null;
   }
+}
+
+/**
+ * Reads and parses deno.json or deno.jsonc from the given directory.
+ * Returns the parsed object, or null if neither file exists or is malformed.
+ * @param {string} dir - Directory to look in.
+ * @returns {object|null}
+ */
+export function readDenoJson(dir) {
+  for (const name of ["deno.json", "deno.jsonc"]) {
+    const filePath = join(dir, name);
+    if (!existsSync(filePath)) continue;
+    try {
+      return JSON.parse(readFileSync(filePath, "utf-8"));
+    } catch {
+      continue;
+    }
+  }
+  return null;
+}
+
+/**
+ * Extracts package names from a Deno import map.
+ * Handles `npm:`, `jsr:` prefixed specifiers and plain URLs.
+ * @param {object|null} denoJson - Parsed deno.json object.
+ * @returns {string[]} Normalised package names.
+ */
+export function getDenoImportNames(denoJson) {
+  if (!denoJson?.imports) return [];
+  return Object.values(denoJson.imports)
+    .filter((s) => typeof s === "string" && (s.startsWith("npm:") || s.startsWith("jsr:")))
+    .map((specifier) => {
+      const bare = specifier.replace(/^(?:npm|jsr):/, "");
+      if (bare.startsWith("@")) {
+        return bare.replace(/^(@[^\/]+\/[^@]+).*$/, "$1");
+      }
+      return bare.replace(/@.*$/, "");
+    });
 }
 
 /**
@@ -273,18 +321,22 @@ export function getAllPackageNames(pkg) {
 function detectTechnologiesInDir(dir) {
   const pkg = readPackageJson(dir);
   const allPackages = getAllPackageNames(pkg);
+  const denoImports = getDenoImportNames(readDenoJson(dir));
+  const allDeps = denoImports.length > 0
+    ? [...new Set([...allPackages, ...denoImports])]
+    : allPackages;
   const detected = [];
 
   for (const tech of SKILLS_MAP) {
     let found = false;
 
     if (tech.detect.packages) {
-      found = tech.detect.packages.some((p) => allPackages.includes(p));
+      found = tech.detect.packages.some((p) => allDeps.includes(p));
     }
 
     if (!found && tech.detect.packagePatterns) {
       found = tech.detect.packagePatterns.some((pattern) =>
-        allPackages.some((p) => pattern.test(p)),
+        allDeps.some((p) => pattern.test(p)),
       );
     }
 
@@ -313,7 +365,7 @@ function detectTechnologiesInDir(dir) {
     }
   }
 
-  const isFrontendByPackages = allPackages.some((p) => FRONTEND_PACKAGES.includes(p));
+  const isFrontendByPackages = allDeps.some((p) => FRONTEND_PACKAGES.includes(p));
   const isFrontendByFiles = hasWebFrontendFiles(dir);
 
   return { detected, isFrontendByPackages, isFrontendByFiles };

--- a/packages/autoskills/tests/detect.test.mjs
+++ b/packages/autoskills/tests/detect.test.mjs
@@ -3,7 +3,7 @@ import assert from "node:assert/strict";
 import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import { getAllPackageNames, readPackageJson, detectTechnologies, detectCombos } from "../lib.mjs";
+import { getAllPackageNames, readPackageJson, readDenoJson, getDenoImportNames, detectTechnologies, detectCombos } from "../lib.mjs";
 
 // ── getAllPackageNames ─────────────────────────────────────────
 
@@ -541,6 +541,153 @@ plugins {
     assert.ok(clerk.skills.includes("clerk/skills/clerk-orgs"));
     assert.ok(clerk.skills.includes("clerk/skills/clerk-webhooks"));
     assert.ok(clerk.skills.includes("clerk/skills/clerk-testing"));
+  });
+
+  it("detects React from deno.json npm: import", () => {
+    writeFileSync(
+      join(tmpDir, "deno.json"),
+      JSON.stringify({ imports: { react: "npm:react@^19", "react-dom": "npm:react-dom@^19" } }),
+    );
+    const { detected } = detectTechnologies(tmpDir);
+    const ids = detected.map((t) => t.id);
+    assert.ok(ids.includes("react"));
+  });
+
+  it("detects Hono from deno.json npm: import", () => {
+    writeFileSync(
+      join(tmpDir, "deno.json"),
+      JSON.stringify({ imports: { hono: "npm:hono@^4" } }),
+    );
+    const { detected } = detectTechnologies(tmpDir);
+    assert.ok(detected.some((t) => t.id === "hono"));
+  });
+
+  it("detects Supabase from deno.json npm: scoped import", () => {
+    writeFileSync(
+      join(tmpDir, "deno.json"),
+      JSON.stringify({ imports: { "@supabase/supabase-js": "npm:@supabase/supabase-js@^2" } }),
+    );
+    const { detected } = detectTechnologies(tmpDir);
+    assert.ok(detected.some((t) => t.id === "supabase"));
+  });
+
+  it("detects frontend from deno.json imports", () => {
+    writeFileSync(
+      join(tmpDir, "deno.json"),
+      JSON.stringify({ imports: { react: "npm:react@^19" } }),
+    );
+    const { isFrontend } = detectTechnologies(tmpDir);
+    assert.strictEqual(isFrontend, true);
+  });
+
+  it("merges package.json and deno.json dependencies", () => {
+    writeFileSync(
+      join(tmpDir, "package.json"),
+      JSON.stringify({ dependencies: { next: "^15" } }),
+    );
+    writeFileSync(
+      join(tmpDir, "deno.json"),
+      JSON.stringify({ imports: { react: "npm:react@^19" } }),
+    );
+    const { detected } = detectTechnologies(tmpDir);
+    const ids = detected.map((t) => t.id);
+    assert.ok(ids.includes("nextjs"));
+    assert.ok(ids.includes("react"));
+  });
+});
+
+// ── readDenoJson ──────────────────────────────────────────────
+
+describe("readDenoJson", () => {
+  let tmpDir;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "autoskills-deno-"));
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("returns null when no deno.json exists", () => {
+    assert.strictEqual(readDenoJson(tmpDir), null);
+  });
+
+  it("parses valid deno.json", () => {
+    const data = { imports: { "@std/path": "jsr:@std/path@^1" } };
+    writeFileSync(join(tmpDir, "deno.json"), JSON.stringify(data));
+    assert.deepStrictEqual(readDenoJson(tmpDir), data);
+  });
+
+  it("parses deno.jsonc when deno.json is absent", () => {
+    const data = { imports: { hono: "npm:hono@^4" } };
+    writeFileSync(join(tmpDir, "deno.jsonc"), JSON.stringify(data));
+    assert.deepStrictEqual(readDenoJson(tmpDir), data);
+  });
+
+  it("prefers deno.json over deno.jsonc", () => {
+    writeFileSync(join(tmpDir, "deno.json"), JSON.stringify({ from: "json" }));
+    writeFileSync(join(tmpDir, "deno.jsonc"), JSON.stringify({ from: "jsonc" }));
+    assert.deepStrictEqual(readDenoJson(tmpDir), { from: "json" });
+  });
+
+  it("returns null for invalid JSON", () => {
+    writeFileSync(join(tmpDir, "deno.json"), "{ not valid }");
+    assert.strictEqual(readDenoJson(tmpDir), null);
+  });
+});
+
+// ── getDenoImportNames ────────────────────────────────────────
+
+describe("getDenoImportNames", () => {
+  it("returns empty array for null input", () => {
+    assert.deepStrictEqual(getDenoImportNames(null), []);
+  });
+
+  it("returns empty array when no imports field", () => {
+    assert.deepStrictEqual(getDenoImportNames({}), []);
+  });
+
+  it("extracts npm: prefixed packages", () => {
+    const result = getDenoImportNames({ imports: { express: "npm:express@^4" } });
+    assert.deepStrictEqual(result, ["express"]);
+  });
+
+  it("extracts jsr: prefixed packages", () => {
+    const result = getDenoImportNames({ imports: { "@std/path": "jsr:@std/path@^1" } });
+    assert.deepStrictEqual(result, ["@std/path"]);
+  });
+
+  it("handles scoped npm packages", () => {
+    const result = getDenoImportNames({
+      imports: { "@supabase/supabase-js": "npm:@supabase/supabase-js@^2" },
+    });
+    assert.deepStrictEqual(result, ["@supabase/supabase-js"]);
+  });
+
+  it("skips non-npm/jsr specifiers", () => {
+    const result = getDenoImportNames({
+      imports: {
+        react: "npm:react@^19",
+        local: "./local.ts",
+        remote: "https://deno.land/x/mod@v1/mod.ts",
+      },
+    });
+    assert.deepStrictEqual(result, ["react"]);
+  });
+
+  it("handles multiple imports", () => {
+    const result = getDenoImportNames({
+      imports: {
+        react: "npm:react@^19",
+        hono: "npm:hono@^4",
+        "@std/fs": "jsr:@std/fs@^1",
+      },
+    });
+    assert.ok(result.includes("react"));
+    assert.ok(result.includes("hono"));
+    assert.ok(result.includes("@std/fs"));
+    assert.strictEqual(result.length, 3);
   });
 });
 

--- a/packages/autoskills/tests/workspace.test.mjs
+++ b/packages/autoskills/tests/workspace.test.mjs
@@ -155,4 +155,69 @@ describe("resolveWorkspaces", () => {
     writeFileSync(join(tmpDir, "package.json"), JSON.stringify({ workspaces: [] }));
     assert.deepStrictEqual(resolveWorkspaces(tmpDir), []);
   });
+
+  it("detects Deno workspace members from deno.json", () => {
+    writeFileSync(
+      join(tmpDir, "deno.json"),
+      JSON.stringify({ workspace: ["./api", "./shared"] }),
+    );
+    mkdirSync(join(tmpDir, "api"), { recursive: true });
+    writeFileSync(join(tmpDir, "api", "deno.json"), "{}");
+    mkdirSync(join(tmpDir, "shared"), { recursive: true });
+    writeFileSync(join(tmpDir, "shared", "deno.json"), "{}");
+
+    const result = resolveWorkspaces(tmpDir);
+    assert.strictEqual(result.length, 2);
+    assert.ok(result.some((d) => d.includes("api")));
+    assert.ok(result.some((d) => d.includes("shared")));
+  });
+
+  it("Deno workspace members with deno.jsonc are detected", () => {
+    writeFileSync(
+      join(tmpDir, "deno.json"),
+      JSON.stringify({ workspace: ["./lib"] }),
+    );
+    mkdirSync(join(tmpDir, "lib"), { recursive: true });
+    writeFileSync(join(tmpDir, "lib", "deno.jsonc"), "{}");
+
+    const result = resolveWorkspaces(tmpDir);
+    assert.strictEqual(result.length, 1);
+    assert.ok(result[0].includes("lib"));
+  });
+
+  it("pnpm-workspace.yaml takes precedence over deno.json workspace", () => {
+    writeFileSync(join(tmpDir, "package.json"), JSON.stringify({}));
+    writeFileSync(join(tmpDir, "pnpm-workspace.yaml"), "packages:\n  - packages/*\n");
+    writeFileSync(
+      join(tmpDir, "deno.json"),
+      JSON.stringify({ workspace: ["./deno-member"] }),
+    );
+    mkdirSync(join(tmpDir, "packages", "core"), { recursive: true });
+    writeFileSync(join(tmpDir, "packages", "core", "package.json"), "{}");
+    mkdirSync(join(tmpDir, "deno-member"), { recursive: true });
+    writeFileSync(join(tmpDir, "deno-member", "deno.json"), "{}");
+
+    const result = resolveWorkspaces(tmpDir);
+    assert.strictEqual(result.length, 1);
+    assert.ok(result[0].includes("core"));
+  });
+
+  it("package.json workspaces take precedence over deno.json workspace", () => {
+    writeFileSync(
+      join(tmpDir, "package.json"),
+      JSON.stringify({ workspaces: ["packages/*"] }),
+    );
+    writeFileSync(
+      join(tmpDir, "deno.json"),
+      JSON.stringify({ workspace: ["./deno-member"] }),
+    );
+    mkdirSync(join(tmpDir, "packages", "ui"), { recursive: true });
+    writeFileSync(join(tmpDir, "packages", "ui", "package.json"), "{}");
+    mkdirSync(join(tmpDir, "deno-member"), { recursive: true });
+    writeFileSync(join(tmpDir, "deno-member", "deno.json"), "{}");
+
+    const result = resolveWorkspaces(tmpDir);
+    assert.strictEqual(result.length, 1);
+    assert.ok(result[0].includes("ui"));
+  });
 });


### PR DESCRIPTION

This pull request adds first-class support for Deno projects in the `autoskills` package by detecting Deno workspaces and dependencies through `deno.json` and `deno.jsonc` files. It updates the detection logic to merge dependencies from both Node and Deno ecosystems, and introduces comprehensive tests to ensure correct behavior.

**Deno workspace and dependency support:**

* The `resolveWorkspaces` function now detects workspace members defined in `deno.json` or `deno.jsonc` files, in addition to existing support for Node.js workspace definitions. [[1]](diffhunk://#diff-341401b57a61dd9fca1710ea77859314026f6723c75d5bee32ae07bfc1f3bc38R236-R245) [[2]](diffhunk://#diff-341401b57a61dd9fca1710ea77859314026f6723c75d5bee32ae07bfc1f3bc38L189-R195)
* New helper functions `readDenoJson` and `getDenoImportNames` are added to read and extract package names from Deno import maps, supporting both `npm:` and `jsr:` specifiers.
* The technology detection logic is updated to merge dependencies from both `package.json` and Deno import maps, ensuring technologies are detected regardless of the ecosystem. [[1]](diffhunk://#diff-341401b57a61dd9fca1710ea77859314026f6723c75d5bee32ae07bfc1f3bc38R324-R339) [[2]](diffhunk://#diff-341401b57a61dd9fca1710ea77859314026f6723c75d5bee32ae07bfc1f3bc38L316-R368)

**Testing improvements:**

* Extensive tests are added to verify detection of technologies and workspace members from Deno configuration files, including precedence rules between Node and Deno workspace definitions. [[1]](diffhunk://#diff-74be9a1ebb0742cc2d25b1cd8dbe80ed7b6a71f8f95c5d4adf9a745af3175bc0R545-R691) [[2]](diffhunk://#diff-35f7c6847ec9b55e99480bb636866da3ef298dde56ff84d76935c8270bfa4a70R158-R222)
* Unit tests for the new helper functions ensure correct parsing and extraction of Deno dependencies.

These changes ensure that `autoskills` can accurately detect and handle modern Deno projects alongside traditional Node.js setups.