### PR TITLE
fix(agents): map .kiro folder to kiro-cli identifier

### DIFF
--- a/packages/autoskills/skills-map.mjs
+++ b/packages/autoskills/skills-map.mjs
@@ -740,7 +740,7 @@ export const AGENT_FOLDER_MAP = {
   ".supermaven": "supermaven",
   ".codebuddy": "codebuddy",
   ".continue": "continue",
-  ".kiro": "kiro",
+  ".kiro": "kiro-cli",
 };
 
 export const WEB_FRONTEND_EXTENSIONS = new Set([

--- a/packages/autoskills/tests/detect-agents.test.mjs
+++ b/packages/autoskills/tests/detect-agents.test.mjs
@@ -26,10 +26,10 @@ describe("detectAgents", () => {
     ok(agents.includes("cursor"));
   });
 
-  it("detects kiro from .kiro/skills", () => {
+  it("detects kiro-cli from .kiro/skills", () => {
     mkdirSync(join(tmp.path, ".kiro", "skills"), { recursive: true });
     const agents = detectAgents(tmp.path);
-    ok(agents.includes("kiro"));
+    ok(agents.includes("kiro-cli"));
   });
 
   it("detects multiple agents", () => {


### PR DESCRIPTION
## Problem
Installation fails for Kiro because `autoskills` passes an invalid agent ID (`kiro`) to the `skills` CLI.

Error:
- `Invalid agents: kiro`
- Expected: `kiro-cli`

## Steps to Reproduce
1. Create a `.kiro/skills` directory
2. Run:
   npx -y skills add addyosmani/web-quality-skills --skill accessibility -y -a kiro
3. Observe validation error

## Root Cause
Outdated agent mapping:
`.kiro` → `kiro` (invalid)

Current CLI expects:
`.kiro` → `kiro-cli`

## Solution
Updated agent mapping:
`.kiro` → `kiro-cli`

Adjusted related detection test accordingly.

## How to Test
- Run:
  CI=1 node --test tests/detect-agents.test.mjs tests/installer.test.mjs
- Verify all tests pass
- Optionally validate CLI with `-a kiro-cli`