### PR TITLE
feat: pre-uncheck already installed skills in multi-select

### DIFF
--- a/packages/autoskills/index.mjs
+++ b/packages/autoskills/index.mjs
@@ -4,7 +4,7 @@ import { resolve, dirname, join } from "node:path";
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 
-import { detectTechnologies, collectSkills, detectAgents } from "./lib.mjs";
+import { detectTechnologies, collectSkills, detectAgents, getInstalledSkillNames, parseSkillPath } from "./lib.mjs";
 import {
   log,
   write,
@@ -166,15 +166,21 @@ function printSkillsList(skills) {
     styledLabel: formatSkillLabel(s.skill, { styled: true }),
   }));
   const maxLen = Math.max(...entries.map((e) => e.label.length));
-  log(cyan("   ◆ ") + bold(`Skills to install `) + dim(`(${skills.length})`));
+  const newCount = skills.filter((s) => !s.installed).length;
+  const installedCount = skills.length - newCount;
+  const countLabel = installedCount > 0
+    ? `(${skills.length}, ${installedCount} already installed)`
+    : `(${skills.length})`;
+  log(cyan("   ◆ ") + bold(`Skills to install `) + dim(countLabel));
   log();
   for (let i = 0; i < entries.length; i++) {
-    const { label, styledLabel, sources } = entries[i];
+    const { label, styledLabel, sources, installed } = entries[i];
     const techSources = sources.filter((s) => !s.includes(" + "));
     const pad = " ".repeat(maxLen - label.length);
     const num = String(i + 1).padStart(2, " ");
-    const suffix = techSources.length > 0 ? `  ${dim(`← ${techSources.join(", ")}`)}` : "";
-    log(dim(`   ${num}.`) + ` ${styledLabel}${pad}${suffix}`);
+    const sourceSuffix = techSources.length > 0 ? `  ${dim(`← ${techSources.join(", ")}`)}` : "";
+    const installedTag = installed ? `  ${dim("(installed)")}` : "";
+    log(dim(`   ${num}.`) + ` ${styledLabel}${pad}${sourceSuffix}${installedTag}`);
   }
   log();
 }
@@ -248,19 +254,26 @@ async function selectSkills(skills, autoYes) {
   }
   const maxLen = Math.max(...[...labelCache.values()].map((v) => v.label.length));
 
-  log(cyan("   ◆ ") + bold(`Select skills to install `) + dim(`(${skills.length} found)`));
+  const newCount = skills.filter((s) => !s.installed).length;
+  const installedCount = skills.length - newCount;
+  const countLabel = installedCount > 0
+    ? `${skills.length} found, ${installedCount} already installed`
+    : `${skills.length} found`;
+  log(cyan("   ◆ ") + bold(`Select skills to install `) + dim(`(${countLabel})`));
   log();
 
   const selected = await multiSelect(skills, {
     labelFn: (s) => {
       const { label, styledLabel } = labelCache.get(s.skill);
-      return styledLabel + " ".repeat(maxLen - label.length);
+      const tag = s.installed ? " " + dim("(installed)") : "";
+      return styledLabel + " ".repeat(maxLen - label.length) + tag;
     },
     hintFn: (s) => {
       const techSources = s.sources.filter((src) => !src.includes(" + "));
       return techSources.length > 1 ? `← ${techSources.join(", ")}` : "";
     },
     groupFn: (s) => s.sources[0],
+    initialSelected: skills.map((s) => !s.installed),
   });
 
   if (selected.length === 0) {
@@ -302,6 +315,10 @@ async function main() {
   printDetected(detected, combos, isFrontend);
 
   const skills = collectSkills(detected, isFrontend, combos);
+  const installedNames = getInstalledSkillNames(projectDir);
+  for (const s of skills) {
+    s.installed = installedNames.has(parseSkillPath(s.skill).skillName);
+  }
   const resolvedAgents = agents.length > 0 ? agents : detectAgents();
 
   if (skills.length === 0) {

--- a/packages/autoskills/lib.mjs
+++ b/packages/autoskills/lib.mjs
@@ -495,6 +495,30 @@ export function parseSkillPath(skill) {
   };
 }
 
+// ── Installed Skills Detection ───────────────────────────────
+
+/**
+ * Returns the names of skills already installed in the project.
+ * Reads `skills-lock.json` first; falls back to directory listing of `.agents/skills/`.
+ * @param {string} projectDir - Absolute path to the project root.
+ * @returns {Set<string>} Skill names (e.g. `"playwright-best-practices"`).
+ */
+export function getInstalledSkillNames(projectDir) {
+  try {
+    const lock = JSON.parse(readFileSync(join(projectDir, "skills-lock.json"), "utf-8"));
+    if (lock?.skills && typeof lock.skills === "object") {
+      return new Set(Object.keys(lock.skills));
+    }
+  } catch {}
+
+  try {
+    const entries = readdirSync(join(projectDir, ".agents", "skills"), { withFileTypes: true });
+    return new Set(entries.filter((e) => e.isDirectory()).map((e) => e.name));
+  } catch {}
+
+  return new Set();
+}
+
 // ── Skill Collection ─────────────────────────────────────────
 
 /**

--- a/packages/autoskills/tests/collect.test.mjs
+++ b/packages/autoskills/tests/collect.test.mjs
@@ -1,6 +1,7 @@
 import { describe, it } from "node:test";
 import { ok, strictEqual, deepStrictEqual } from "node:assert/strict";
-import { collectSkills } from "../lib.mjs";
+import { collectSkills, getInstalledSkillNames } from "../lib.mjs";
+import { useTmpDir, writeJson, writeFile } from "./helpers.mjs";
 
 describe("collectSkills", () => {
   it("returns empty array when no technologies detected", () => {
@@ -211,5 +212,55 @@ describe("collectSkills", () => {
 
     strictEqual(skills.length, 1);
     strictEqual(skills[0].skill, "vercel-labs/agent-skills/vercel-react-best-practices");
+  });
+
+});
+
+describe("getInstalledSkillNames", () => {
+  const tmp = useTmpDir();
+
+  it("returns empty set when no lockfile and no .agents dir", () => {
+    const result = getInstalledSkillNames(tmp.path);
+    strictEqual(result.size, 0);
+  });
+
+  it("reads skill names from skills-lock.json", () => {
+    writeJson(tmp.path, "skills-lock.json", {
+      version: 1,
+      skills: {
+        "playwright-best-practices": { source: "currents-dev/playwright-best-practices-skill" },
+        "neon-postgres": { source: "neondatabase/agent-skills" },
+      },
+    });
+    const result = getInstalledSkillNames(tmp.path);
+    strictEqual(result.size, 2);
+    ok(result.has("playwright-best-practices"));
+    ok(result.has("neon-postgres"));
+  });
+
+  it("falls back to .agents/skills/ directory when no lockfile", () => {
+    writeFile(tmp.path, ".agents/skills/next-best-practices/.keep");
+    writeFile(tmp.path, ".agents/skills/shadcn/.keep");
+    const result = getInstalledSkillNames(tmp.path);
+    strictEqual(result.size, 2);
+    ok(result.has("next-best-practices"));
+    ok(result.has("shadcn"));
+  });
+
+  it("prefers lockfile over directory listing", () => {
+    writeJson(tmp.path, "skills-lock.json", {
+      version: 1,
+      skills: { "from-lock": { source: "test/repo" } },
+    });
+    writeFile(tmp.path, ".agents/skills/from-dir/.keep");
+    const result = getInstalledSkillNames(tmp.path);
+    strictEqual(result.size, 1);
+    ok(result.has("from-lock"));
+  });
+
+  it("returns empty set for invalid lockfile JSON", () => {
+    writeFile(tmp.path, "skills-lock.json", "not json{{{");
+    const result = getInstalledSkillNames(tmp.path);
+    strictEqual(result.size, 0);
   });
 });

--- a/packages/autoskills/ui.mjs
+++ b/packages/autoskills/ui.mjs
@@ -50,11 +50,13 @@ export function printBanner(version) {
  * Interactive multi-select with optional group headers.
  * All items are selected by default.
  */
-export function multiSelect(items, { labelFn, hintFn, groupFn }) {
+export function multiSelect(items, { labelFn, hintFn, groupFn, initialSelected }) {
   if (!process.stdin.isTTY) return Promise.resolve(items);
 
   return new Promise((resolve) => {
-    const selected = Array.from({ length: items.length }, () => true);
+    const selected = initialSelected
+      ? initialSelected.slice()
+      : Array.from({ length: items.length }, () => true);
     let cursor = 0;
     let rendered = false;
 


### PR DESCRIPTION
## Summary

- When a project already has skills installed (via `skills-lock.json` or `.agents/skills/`), those skills now appear **unchecked by default** in the multi-select. Users can still re-check them to force an update.
- Added `getInstalledSkillNames(projectDir)` that reads `skills-lock.json` first, falls back to `.agents/skills/` directory listing
- Updated `multiSelect()` to accept `initialSelected` for pre-unchecking
- Shows `(installed)` tag and count summary in both `--dry-run` and interactive mode

## Before / After

**Before:** All 26 skills are checked. User has to manually uncheck the 17 already installed.

**After:** Only the 9 new skills are checked. Already installed skills show `(installed)` and are unchecked. User can re-check them to update.

## Test plan

- [x] `getInstalledSkillNames`: reads lockfile, falls back to directory, handles invalid JSON, empty project
- [x] Full suite passes: 191/191 green
- [x] Manual test on beeheroes project with 17 installed skills

🤖 Generated with [Claude Code](https://claude.com/claude-code)