### PR TITLE
feat(agents): add OpenCode detection

### DIFF
--- a/packages/autoskills/skills-map.mjs
+++ b/packages/autoskills/skills-map.mjs
@@ -731,6 +731,7 @@ export const AGENT_FOLDER_MAP = {
   ".cursor": "cursor",
   ".cline": "cline",
   ".codex": "codex",
+  ".opencode": "opencode",
   ".antigravity": "antigravity",
   ".augment": "augment",
   ".copilot": "github-copilot",

--- a/packages/autoskills/tests/detect-agents.test.mjs
+++ b/packages/autoskills/tests/detect-agents.test.mjs
@@ -26,6 +26,12 @@ describe("detectAgents", () => {
     ok(agents.includes("cursor"));
   });
 
+  it("detects opencode from .opencode/skills", () => {
+    mkdirSync(join(tmp.path, ".opencode", "skills"), { recursive: true });
+    const agents = detectAgents(tmp.path);
+    ok(agents.includes("opencode"));
+  });
+
   it("detects kiro-cli from .kiro/skills", () => {
     mkdirSync(join(tmp.path, ".kiro", "skills"), { recursive: true });
     const agents = detectAgents(tmp.path);


### PR DESCRIPTION
## Summary
- Add `.opencode` → `opencode` mapping to `AGENT_FOLDER_MAP` so autoskills auto-detects OpenCode.
- Add regression test for OpenCode detection.

Replaces #40 with a minimal, correct implementation — no unnecessary wrappers or refactors.

### Why not merge #40 directly?

The original PR had several issues:
1. **`hasAgentSkillsDir` wrapper is unnecessary** — `existsSync` never throws by design
2. **Gratuitous refactor** — replaced cached `AGENT_FOLDER_ENTRIES` with `Object.entries(AGENT_FOLDER_MAP)` on each call for no benefit
3. **Broken tests** — used `assert.ok()` instead of destructured `ok()` (project convention), and referenced `tmpHome` which doesn't exist (`tmp.path` is the correct variable)
4. **Inconsistent help text** — showed `OpenCode` (capitalized) but the agent identifier is `opencode` (lowercase)

The actual change needed is **one line** in the agent map + a test.

Closes #40

## Test plan
- [x] `node --test tests/detect-agents.test.mjs` — 9/9 pass including new OpenCode test
- [x] Full suite: 191/192 pass (1 pre-existing failure in `collect.test.mjs` unrelated to this change)