### PR TITLE
fix: detect technologies in Gradle multi-module projects via settings gradle (#26)

### DIFF
--- a/packages/autoskills/lib.mjs
+++ b/packages/autoskills/lib.mjs
@@ -52,8 +52,32 @@ const GRADLE_SCAN_ROOT_FILES = [
 // ── Gradle Scanning ──────────────────────────────────────────
 
 /**
+ * Extracts module paths declared in a `settings.gradle(.kts)` file.
+ * Handles both Kotlin DSL (`include("mod:sub")`) and Groovy (`include 'mod:sub'`)
+ * syntaxes, including multiple modules on a single line.
+ * Colon-separated module names are converted to filesystem paths (`adapters:web` → `adapters/web`).
+ * @param {string} content - Raw file content of settings.gradle(.kts).
+ * @returns {string[]} Module directory paths relative to the project root.
+ */
+function parseSettingsGradleModules(content) {
+  const modules = [];
+  const includeRe = /include\s*\(?\s*([^)]+)/g;
+  const quotedRe = /['"]([^'"]+)['"]/g;
+  let includeMatch;
+  while ((includeMatch = includeRe.exec(content)) !== null) {
+    const args = includeMatch[1];
+    let quotedMatch;
+    while ((quotedMatch = quotedRe.exec(args)) !== null) {
+      modules.push(quotedMatch[1].replace(/:/g, "/"));
+    }
+  }
+  return modules;
+}
+
+/**
  * Builds a list of Gradle build file paths to scan for technology markers.
- * Includes root-level Gradle files and `build.gradle(.kts)` inside immediate subdirectories.
+ * Includes root-level Gradle files, `build.gradle(.kts)` inside immediate subdirectories,
+ * and modules declared in `settings.gradle(.kts)`.
  * @param {string} projectDir - Absolute path to the project root.
  * @returns {string[]} Candidate file paths.
  */
@@ -64,8 +88,17 @@ function gradleLayoutCandidatePaths(projectDir) {
   if (cached) return cached;
 
   const candidates = [];
+  const seen = new Set();
+
+  function add(filePath) {
+    if (!seen.has(filePath)) {
+      candidates.push(filePath);
+      seen.add(filePath);
+    }
+  }
+
   for (const f of GRADLE_SCAN_ROOT_FILES) {
-    candidates.push(join(projectDir, f));
+    add(join(projectDir, f));
   }
   let entries;
   try {
@@ -76,9 +109,27 @@ function gradleLayoutCandidatePaths(projectDir) {
   for (const e of entries) {
     if (!e.isDirectory() || e.name.startsWith(".") || SCAN_SKIP_DIRS.has(e.name)) continue;
     for (const g of ["build.gradle.kts", "build.gradle"]) {
-      candidates.push(join(projectDir, e.name, g));
+      add(join(projectDir, e.name, g));
     }
   }
+
+  // Parse settings.gradle(.kts) for declared modules (handles deep nesting)
+  for (const settingsFile of ["settings.gradle.kts", "settings.gradle"]) {
+    const settingsPath = join(projectDir, settingsFile);
+    let content;
+    try {
+      content = readFileSync(settingsPath, "utf-8");
+    } catch {
+      continue;
+    }
+    for (const modulePath of parseSettingsGradleModules(content)) {
+      for (const g of ["build.gradle.kts", "build.gradle"]) {
+        add(join(projectDir, modulePath, g));
+      }
+    }
+    break; // only use the first settings file found
+  }
+
   _gradleCache.set(projectDir, candidates);
   return candidates;
 }

--- a/packages/autoskills/tests/cli.test.mjs
+++ b/packages/autoskills/tests/cli.test.mjs
@@ -437,6 +437,27 @@ describe("CLI", () => {
       ok(output.includes("Node.js"));
     });
 
+    it("detects technologies from Gradle multi-module project with --dry-run", () => {
+      writePackageJson(tmp.path);
+      writeFile(
+        tmp.path,
+        "settings.gradle.kts",
+        'rootProject.name = "my-app"\ninclude("adapters:web")',
+      );
+      writeFile(tmp.path, "build.gradle.kts", "sourceCompatibility = JavaVersion.VERSION_17");
+      writeFile(
+        tmp.path,
+        "adapters/web/build.gradle.kts",
+        'plugins { id("org.springframework.boot") }',
+      );
+      writeFile(tmp.path, "src/main/resources/application.properties", "server.port=8080");
+
+      const output = run(["--dry-run"], tmp.path);
+
+      ok(output.includes("Java"));
+      ok(output.includes("Spring Boot"));
+    });
+
     it("adds web fundamentals when npm frontend is detected too", () => {
       writePackageJson(tmp.path, { dependencies: { react: "^19", next: "^15" } });
 

--- a/packages/autoskills/tests/detect.test.mjs
+++ b/packages/autoskills/tests/detect.test.mjs
@@ -265,6 +265,64 @@ plugins {
     ok(ids.includes("android"));
   });
 
+  it("detects Java from nested Gradle module declared in settings.gradle.kts", () => {
+    writePackageJson(tmp.path);
+    writeFile(
+      tmp.path,
+      "settings.gradle.kts",
+      'rootProject.name = "my-app"\ninclude("adapters:web")',
+    );
+    writeFile(
+      tmp.path,
+      "adapters/web/build.gradle.kts",
+      "sourceCompatibility = JavaVersion.VERSION_17",
+    );
+    const { detected } = detectTechnologies(tmp.path);
+    ok(detected.some((t) => t.id === "java"));
+  });
+
+  it("detects Kotlin Multiplatform from nested module declared in settings.gradle", () => {
+    writePackageJson(tmp.path);
+    writeFile(tmp.path, "settings.gradle", "include 'shared'");
+    writeFile(tmp.path, "shared/build.gradle.kts", 'plugins { kotlin("multiplatform") }');
+    const { detected } = detectTechnologies(tmp.path);
+    ok(detected.some((t) => t.id === "kotlin-multiplatform"));
+  });
+
+  it("detects Android from deeply nested module in Gradle multi-module project", () => {
+    writePackageJson(tmp.path);
+    writeFile(tmp.path, "settings.gradle.kts", 'include("feature:login")');
+    writeFile(
+      tmp.path,
+      "feature/login/build.gradle.kts",
+      'plugins { id("com.android.library") }',
+    );
+    const { detected } = detectTechnologies(tmp.path);
+    ok(detected.some((t) => t.id === "android"));
+  });
+
+  it("handles settings.gradle with multiple includes on one line", () => {
+    writePackageJson(tmp.path);
+    writeFile(tmp.path, "settings.gradle", "include 'app', 'core', 'data'");
+    writeFile(
+      tmp.path,
+      "app/build.gradle.kts",
+      'plugins { id("java-library") }',
+    );
+    const { detected } = detectTechnologies(tmp.path);
+    ok(detected.some((t) => t.id === "java"));
+  });
+
+  it("handles settings.gradle.kts with multi-line includes", () => {
+    writePackageJson(tmp.path);
+    writeFile(tmp.path, "settings.gradle.kts", 'include(\n  ":app",\n  ":core"\n)');
+    writeFile(tmp.path, "app/build.gradle.kts", 'plugins { id("java-library") }');
+    writeFile(tmp.path, "core/build.gradle.kts", 'plugins { kotlin("multiplatform") }');
+    const { detected } = detectTechnologies(tmp.path);
+    ok(detected.some((t) => t.id === "java"));
+    ok(detected.some((t) => t.id === "kotlin-multiplatform"));
+  });
+
   it("detects Java from pom.xml (Maven project)", () => {
     writeFile(tmp.path, "pom.xml", "<project><groupId>com.example</groupId></project>");
     const { detected } = detectTechnologies(tmp.path);


### PR DESCRIPTION
….gradle (#26)

## What Changed

- Added `parseSettingsGradleModules()` helper in `lib.mjs` that extracts module paths from `settings.gradle(.kts)`, supporting both Kotlin DSL (`include("mod:sub")`) and Groovy (`include 'mod:sub'`) syntaxes, including multi-line declarations
- Enhanced `gradleLayoutCandidatePaths()` to parse declared modules from `settings.gradle(.kts)` and add their `build.gradle(.kts)` files as scan candidates, with deduplication
- Colon-separated module paths are converted to filesystem paths (`adapters:web` → `adapters/web/`)

## Why This Change

Fixes #26. In Gradle multi-module projects (common in hexagonal/clean architecture), dependencies like Spring Boot or Kotlin Multiplatform are defined in nested modules (`adapters/web/build.gradle.kts`) at 2+ levels deep. The previous scan only checked immediate subdirectories, missing these modules entirely and reporting "No supported technologies detected."

## Testing Done

- [x] Manual testing completed (hexagonal Gradle project with nested modules, multi-line includes, leading colon syntax)
- [x] Automated tests pass locally (all 209 tests)
- [x] Edge cases considered and tested

## Type of Change

- [x] `fix:` Bug fix
- [ ] `feat:` New feature
- [ ] `refactor:` Code refactoring
- [ ] `docs:` Documentation
- [x] `test:` Tests
- [ ] `chore:` Maintenance/tooling

## Security & Quality Checklist

- [x] No secrets or API keys committed
- [x] Follows the project's coding standards
- [x] No sensitive data exposed in logs or output

## Documentation

- [ ] Updated relevant documentation
- [x] Added comments for complex logic
- [ ] README updated (if needed)
