### PR TITLE
feat: generate CLAUDE.md summary for Claude Code installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,13 @@ npx autoskills
 1. Run `npx autoskills` in your project root
 2. Your `package.json`, Gradle files, and config files are scanned to detect technologies
 3. The best matching AI agent skills are installed via [skills.sh](https://skills.sh)
+4. If Claude Code is targeted, a `CLAUDE.md` summary is generated from the installed markdown files in `.claude/skills`
 
 That's it. No config needed.
+
+## Claude Code summary
+
+If `claude-code` is auto-detected or passed with `-a`, `autoskills` also writes a `CLAUDE.md` file in your project root with a quick summary of the markdown files installed for Claude Code.
 
 ## Options
 

--- a/packages/autoskills/README.md
+++ b/packages/autoskills/README.md
@@ -22,6 +22,7 @@ That's it. It will:
 2. **Detect** every technology in your stack
 3. **Show** an interactive selector with the best skills for your project
 4. **Install** them in parallel with live progress
+5. **Generate `CLAUDE.md` automatically** when Claude Code is one of the target agents
 
 ### Skip the prompt
 
@@ -34,6 +35,10 @@ npx autoskills -y
 ```bash
 npx autoskills --dry-run
 ```
+
+### Claude Code summary
+
+If `claude-code` is auto-detected or passed with `-a`, `autoskills` writes a `CLAUDE.md` file in your project root summarizing the markdown files installed under `.claude/skills`.
 
 ## Options
 

--- a/packages/autoskills/claude.mjs
+++ b/packages/autoskills/claude.mjs
@@ -1,0 +1,162 @@
+import { existsSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join, relative } from "node:path";
+
+/**
+ * Returns true when Claude Code is one of the target agents.
+ * @param {string[]} agents
+ * @returns {boolean}
+ */
+export function shouldGenerateClaudeMd(agents = []) {
+  return agents.includes("claude-code");
+}
+
+/**
+ * Recursively collects markdown files from a directory.
+ * @param {string} dir
+ * @returns {string[]}
+ */
+function collectMarkdownFiles(dir) {
+  let entries;
+  try {
+    entries = readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+
+  const files = [];
+  for (const entry of entries) {
+    const fullPath = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...collectMarkdownFiles(fullPath));
+      continue;
+    }
+
+    if (entry.isFile() && entry.name.toLowerCase().endsWith(".md")) {
+      files.push(fullPath);
+    }
+  }
+
+  return files;
+}
+
+/**
+ * Extracts a compact summary from a markdown document.
+ * Uses the first heading as title and the first paragraph outside code fences as summary.
+ * @param {string} markdown
+ * @returns {{ title: string|null, summary: string|null }}
+ */
+export function summarizeMarkdown(markdown) {
+  const lines = markdown.split(/\r?\n/);
+  let title = null;
+  let summary = null;
+  let inCodeFence = false;
+  const paragraph = [];
+
+  for (const rawLine of lines) {
+    const line = rawLine.trim();
+
+    if (line.startsWith("```")) {
+      inCodeFence = !inCodeFence;
+      continue;
+    }
+
+    if (inCodeFence) continue;
+
+    if (!title && line.startsWith("#")) {
+      title = line.replace(/^#+\s*/, "").trim() || null;
+      continue;
+    }
+
+    if (!line) {
+      if (paragraph.length > 0) {
+        summary = paragraph.join(" ").trim();
+        break;
+      }
+      continue;
+    }
+
+    if (/^#{1,6}\s/.test(line)) continue;
+    if (/^[-*]\s+/.test(line) && paragraph.length === 0) continue;
+    if (/^\d+\.\s+/.test(line) && paragraph.length === 0) continue;
+    if (/^[>|`]/.test(line)) continue;
+
+    paragraph.push(line);
+  }
+
+  if (!summary && paragraph.length > 0) {
+    summary = paragraph.join(" ").trim();
+  }
+
+  if (summary) {
+    summary = summary.replace(/\s+/g, " ");
+    if (summary.length > 220) {
+      summary = `${summary.slice(0, 217).trimEnd()}...`;
+    }
+  }
+
+  return { title, summary };
+}
+
+/**
+ * Builds a CLAUDE.md summary from installed Claude Code skills.
+ * @param {string} projectDir
+ * @returns {{ generated: boolean, outputPath: string, files: number }}
+ */
+export function generateClaudeMd(projectDir) {
+  const skillsDir = join(projectDir, ".claude", "skills");
+  const outputPath = join(projectDir, "CLAUDE.md");
+
+  if (!existsSync(skillsDir)) {
+    return { generated: false, outputPath, files: 0 };
+  }
+
+  const markdownFiles = collectMarkdownFiles(skillsDir).sort((a, b) => a.localeCompare(b));
+  if (markdownFiles.length === 0) {
+    return { generated: false, outputPath, files: 0 };
+  }
+
+  const sections = [];
+  for (const filePath of markdownFiles) {
+    const relativePath = relative(projectDir, filePath).replaceAll("\\", "/");
+    const skillName = relative(skillsDir, filePath).split(/[/\\]/)[0] || "unknown-skill";
+    const markdown = readFileSync(filePath, "utf-8");
+    const { title, summary } = summarizeMarkdown(markdown);
+    sections.push({
+      skillName,
+      relativePath,
+      title: title || skillName,
+      summary: summary || "No inline summary found. Review the source markdown for details.",
+    });
+  }
+
+  const grouped = new Map();
+  for (const section of sections) {
+    if (!grouped.has(section.skillName)) {
+      grouped.set(section.skillName, []);
+    }
+    grouped.get(section.skillName).push(section);
+  }
+
+  const lines = [
+    "# CLAUDE.md",
+    "",
+    "Resumen generado por `autoskills` a partir de los markdown instalados para Claude Code.",
+    "Úsalo como guía rápida antes de consultar los archivos completos dentro de `.claude/skills`.",
+    "",
+  ];
+
+  for (const [skillName, entries] of grouped) {
+    lines.push(`## ${skillName}`);
+    lines.push("");
+    for (const entry of entries) {
+      lines.push(`### ${entry.title}`);
+      lines.push("");
+      lines.push(`- Fuente: \`${entry.relativePath}\``);
+      lines.push(`- Resumen: ${entry.summary}`);
+      lines.push("");
+    }
+  }
+
+  writeFileSync(outputPath, `${lines.join("\n").trimEnd()}\n`);
+  return { generated: true, outputPath, files: markdownFiles.length };
+}

--- a/packages/autoskills/index.mjs
+++ b/packages/autoskills/index.mjs
@@ -21,6 +21,7 @@ import {
 } from "./colors.mjs";
 import { printBanner, multiSelect, formatTime } from "./ui.mjs";
 import { installAll, resolveSkillsBin } from "./installer.mjs";
+import { shouldGenerateClaudeMd, generateClaudeMd } from "./claude.mjs";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const VERSION = JSON.parse(readFileSync(join(__dirname, "package.json"), "utf-8")).version;
@@ -352,6 +353,9 @@ async function main() {
   if (dryRun) {
     printSkillsList(skills);
     log(dim(`   Agents: ${resolvedAgents.join(", ")}`));
+    if (shouldGenerateClaudeMd(resolvedAgents)) {
+      log(dim("   Claude Code detected: `CLAUDE.md` will be generated after install."));
+    }
     log(dim("   --dry-run: nothing was installed."));
     log();
     process.exit(0);
@@ -373,6 +377,11 @@ async function main() {
   const startTime = Date.now();
   const { installed, failed, errors } = await installAll(selectedSkills, resolvedAgents);
   const elapsed = Date.now() - startTime;
+  let claudeSummary = null;
+
+  if (shouldGenerateClaudeMd(resolvedAgents) && installed > 0) {
+    claudeSummary = generateClaudeMd(projectDir);
+  }
 
   if (process.stdout.isTTY) {
     const up = selectedSkills.length + 2;
@@ -382,6 +391,16 @@ async function main() {
   }
 
   printSummary({ installed, failed, errors, elapsed, verbose });
+
+  if (shouldGenerateClaudeMd(resolvedAgents)) {
+    if (claudeSummary?.generated) {
+      log(dim(`   Claude Code summary written to CLAUDE.md (${claudeSummary.files} markdown files).`));
+      log();
+    } else {
+      log(dim("   Claude Code detected, but no markdown files were found under .claude/skills."));
+      log();
+    }
+  }
 }
 
 main().catch((err) => {

--- a/packages/autoskills/package.json
+++ b/packages/autoskills/package.json
@@ -33,7 +33,7 @@
   ],
   "type": "module",
   "scripts": {
-    "test": "node --test 'tests/*.test.mjs'",
+    "test": "node --test tests",
     "release": "node scripts/release.mjs",
     "bench": "node scripts/bench.mjs"
   },

--- a/packages/autoskills/tests/claude.test.mjs
+++ b/packages/autoskills/tests/claude.test.mjs
@@ -1,0 +1,87 @@
+import { describe, it } from "node:test";
+import { ok, strictEqual } from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { useTmpDir, writeFile } from "./helpers.mjs";
+import { shouldGenerateClaudeMd, summarizeMarkdown, generateClaudeMd } from "../claude.mjs";
+
+describe("shouldGenerateClaudeMd", () => {
+  it("returns true when claude-code is selected", () => {
+    strictEqual(shouldGenerateClaudeMd(["universal", "claude-code"]), true);
+  });
+
+  it("returns false when claude-code is not selected", () => {
+    strictEqual(shouldGenerateClaudeMd(["universal", "cursor"]), false);
+  });
+});
+
+describe("summarizeMarkdown", () => {
+  it("extracts the first heading and paragraph", () => {
+    const result = summarizeMarkdown(`# React Skill
+
+Best practices for building React apps with this stack.
+
+## Details
+More text.
+`);
+
+    strictEqual(result.title, "React Skill");
+    strictEqual(result.summary, "Best practices for building React apps with this stack.");
+  });
+
+  it("ignores code fences before the summary", () => {
+    const result = summarizeMarkdown(`# Example
+
+\`\`\`js
+console.log("test")
+\`\`\`
+
+Use this skill to guide API integrations.
+`);
+
+    strictEqual(result.title, "Example");
+    strictEqual(result.summary, "Use this skill to guide API integrations.");
+  });
+});
+
+describe("generateClaudeMd", () => {
+  const tmp = useTmpDir();
+
+  it("returns generated=false when .claude/skills does not exist", () => {
+    const result = generateClaudeMd(tmp.path);
+    strictEqual(result.generated, false);
+    strictEqual(result.files, 0);
+  });
+
+  it("builds CLAUDE.md from markdown files under .claude/skills", () => {
+    writeFile(
+      tmp.path,
+      ".claude/skills/react-best-practices/SKILL.md",
+      `# React Best Practices
+
+Use this skill to keep components small and predictable.
+`,
+    );
+    writeFile(
+      tmp.path,
+      ".claude/skills/react-best-practices/README.md",
+      `# React Skill Notes
+
+Remember to prefer composition over inheritance.
+`,
+    );
+
+    const result = generateClaudeMd(tmp.path);
+    const output = readFileSync(join(tmp.path, "CLAUDE.md"), "utf-8");
+
+    strictEqual(result.generated, true);
+    strictEqual(result.files, 2);
+    ok(output.includes("# CLAUDE.md"));
+    ok(output.includes("## react-best-practices"));
+    ok(output.includes("### React Best Practices"));
+    ok(output.includes("Use this skill to keep components small and predictable."));
+    ok(output.includes("### React Skill Notes"));
+    ok(output.includes("`.claude/skills/react-best-practices/SKILL.md`"));
+  });
+});


### PR DESCRIPTION
Closes #60

## Summary

Automatically generates a `CLAUDE.md` file when `claude-code` is one of the target agents.

## Changes

- add Claude Code summary generation from markdown files under `.claude/skills`
- wire summary generation into the CLI install flow
- show dry-run messaging for Claude Code summary generation
- document the new behavior in both READMEs
- add tests for the new Claude summary feature
- fix the package test script so it works correctly in PowerShell/Windows

## Verification

- Ran `node --test tests` in `packages/autoskills`
- Result: 212 tests passed