### PR TITLE
feat: add Laravel detection with multi-signal approach

### DIFF
--- a/packages/autoskills/skills-map.mjs
+++ b/packages/autoskills/skills-map.mjs
@@ -678,6 +678,18 @@ export const SKILLS_MAP = [
     skills: [],
   },
   {
+    id: "laravel",
+    name: "Laravel",
+    detect: {
+      configFiles: ["artisan", "bootstrap/app.php"],
+      configFileContent: {
+        files: ["composer.json"],
+        patterns: ["laravel/framework", "illuminate/"],
+      },
+    },
+    skills: ["jpcaparas/superpowers-laravel"],
+  },
+  {
     id: "fastapi",
     name: "FastAPI",
     detect: {

--- a/packages/autoskills/tests/detect.test.mjs
+++ b/packages/autoskills/tests/detect.test.mjs
@@ -544,6 +544,56 @@ plugins {
     ok(!detected.some((t) => t.id === "php"));
   });
 
+  it("detects Laravel from artisan file", () => {
+    writeFile(tmp.path, "artisan", "#!/usr/bin/env php\n<?php\ndefine('LARAVEL_START', microtime(true));");
+    const { detected } = detectTechnologies(tmp.path);
+    ok(detected.some((t) => t.id === "laravel"));
+  });
+
+  it("detects Laravel from bootstrap/app.php", () => {
+    writeFile(tmp.path, "bootstrap/app.php", "return $app;");
+    const { detected } = detectTechnologies(tmp.path);
+    ok(detected.some((t) => t.id === "laravel"));
+  });
+
+  it("detects Laravel from composer.json with laravel/framework", () => {
+    writeFile(
+      tmp.path,
+      "composer.json",
+      JSON.stringify({ require: { "laravel/framework": "^11.0" } }),
+    );
+    const { detected } = detectTechnologies(tmp.path);
+    ok(detected.some((t) => t.id === "laravel"));
+  });
+
+  it("detects Laravel from composer.json with illuminate packages", () => {
+    writeFile(
+      tmp.path,
+      "composer.json",
+      JSON.stringify({ require: { "illuminate/support": "^11.0" } }),
+    );
+    const { detected } = detectTechnologies(tmp.path);
+    ok(detected.some((t) => t.id === "laravel"));
+  });
+
+  it("returns correct skills for Laravel detection", () => {
+    writeFile(
+      tmp.path,
+      "composer.json",
+      JSON.stringify({ require: { "laravel/framework": "^11.0" } }),
+    );
+    const { detected } = detectTechnologies(tmp.path);
+    const laravel = detected.find((t) => t.id === "laravel");
+    ok(laravel);
+    ok(laravel.skills.includes("jpcaparas/superpowers-laravel"));
+  });
+
+  it("does not detect Laravel without Laravel files or packages", () => {
+    writePackageJson(tmp.path, { dependencies: { express: "^4.0.0" } });
+    const { detected } = detectTechnologies(tmp.path);
+    ok(!detected.some((t) => t.id === "laravel"));
+  });
+
   it("detects Chrome Extension from manifest.json with manifest_version", () => {
     writeFile(
       tmp.path,


### PR DESCRIPTION
## Summary

- Add Laravel framework detection to autoskills
- Detect Laravel via multiple signals: `artisan` file, `bootstrap/app.php`, or `composer.json` with `laravel/framework`
- Include `jpcaparas/superpowers-laravel` skill as the default Laravel skill
- Add 6 test cases covering all detection scenarios

## Changes

### Detection Approach
Laravel is detected using a multi-signal approach:
1. **configFiles**: Check for `artisan` or `bootstrap/app.php`
2. **configFileContent**: Check `composer.json` for `laravel/framework` or `illuminate/*` packages

This follows the same pattern as other frameworks like Django and Spring Boot.

### Files Changed
- `packages/autoskills/skills-map.mjs` - Added Laravel entry
- `packages/autoskills/tests/detect.test.mjs` - Added 6 test cases

## Testing
All 141 tests pass including the 6 new Laravel detection tests.

### Test Coverage
- ✅ Detects Laravel from `artisan` file
- ✅ Detects Laravel from `bootstrap/app.php`  
- ✅ Detects Laravel from `composer.json` with `laravel/framework`
- ✅ Detects Laravel from `composer.json` with `illuminate/*` packages
- ✅ Returns correct skills for Laravel detection
- ✅ Does not detect Laravel without Laravel files/packages

---

Closes #55
