### PR TITLE
feat(autoskills): add interactive agent selection prompt

### DIFF
--- a/packages/autoskills/main.ts
+++ b/packages/autoskills/main.ts
@@ -358,6 +358,46 @@ async function selectSkills(skills: SkillEntry[], autoYes: boolean): Promise<Ski
   return selected;
 }
 
+// ── Agent Selection ──────────────────────────────────────────
+
+async function selectAgents(
+  detectedAgents: string[],
+  autoYes: boolean,
+  hasExplicitAgent: boolean,
+): Promise<string[]> {
+  const explicitAgents = detectedAgents.filter((a) => a !== "universal");
+
+  // Skip prompt when: explicit -a flag, auto-yes, or only 0-1 explicit agents detected
+  if (hasExplicitAgent || autoYes || explicitAgents.length <= 1) {
+    return detectedAgents;
+  }
+
+  log();
+  log(cyan("   ◆ ") + bold(`Select target agents `) + dim(`(${explicitAgents.length} detected)`));
+  log();
+
+  const selected = await multiSelect(explicitAgents, {
+    labelFn: (agent: string) => agent,
+    initialSelected: explicitAgents.map(() => true),
+    shortcuts: [
+      {
+        key: "n",
+        label: "none",
+        fn: (items: string[]) => items.map(() => false),
+      },
+    ],
+  });
+
+  if (selected.length === 0) {
+    log();
+    log(dim("   No agents selected. Only 'universal' will be used."));
+    log();
+    return ["universal"];
+  }
+
+  return ["universal", ...selected];
+}
+
 // ── Main ─────────────────────────────────────────────────────
 
 async function main(): Promise<void> {
@@ -412,6 +452,7 @@ async function main(): Promise<void> {
   }
 
   const selectedSkills = await selectSkills(skills, autoYes);
+  const selectedAgents = await selectAgents(resolvedAgents, autoYes, agents.length > 0);
 
   if (!autoYes && process.stdout.isTTY) {
     write("\x1b[H\x1b[2J\x1b[3J");
@@ -421,15 +462,15 @@ async function main(): Promise<void> {
   }
 
   log(cyan("   ◆ ") + bold("Installing skills..."));
-  log(dim(`   Agents: ${resolvedAgents.join(", ")}`));
+  log(dim(`   Agents: ${selectedAgents.join(", ")}`));
   log();
 
   const startTime = Date.now();
-  const { installed, failed, errors } = await installAll(selectedSkills, resolvedAgents);
+  const { installed, failed, errors } = await installAll(selectedSkills, selectedAgents);
   const elapsed = Date.now() - startTime;
   let claudeSummary: { generated: boolean; files: number } | null = null;
 
-  if (shouldGenerateClaudeMd(resolvedAgents)) {
+  if (shouldGenerateClaudeMd(selectedAgents)) {
     claudeSummary = generateClaudeMd(projectDir);
   }
 
@@ -442,7 +483,7 @@ async function main(): Promise<void> {
 
   printSummary({ installed, failed, errors, elapsed, verbose });
 
-  if (shouldGenerateClaudeMd(resolvedAgents)) {
+  if (shouldGenerateClaudeMd(selectedAgents)) {
     if (claudeSummary?.generated) {
       log(
         dim(`   Claude Code summary written to CLAUDE.md (${claudeSummary.files} markdown files).`),


### PR DESCRIPTION
## 🎯 Qué resuelve esto
Cuando usas `autoskills`, el CLI detecta **todos** los agentes que tienes instalados (Claude Code, Cursor, Cline, Codex, etc.) y les instala los skills a **todos** de golpe. No hay forma de elegir.
Esto está bien si solo usas uno o dos, pero si tienes 10+ agentes instalados (como yo 😅), quizás no quieras instalar en todos.
## ✨ Qué cambia
Ahora aparece un **prompt interactivo** para elegir en qué agentes instalar, justo después de seleccionar los skills:
   ◆ Select skills to install (9 found)
 ❯ ◼ astrolicious › astro
   ◼ wshobson › typescript-advanced-types
   ...
   ◆ Select target agents (11 detected)
 ❯ ◼ claude-code
   ◼ cursor
   ◼ cline
   ◼ codex
   ◼ opencode
   ...
   ↑↓ move · space toggle · a all · n none · enter confirm (11/11)
## 🛠️ Cómo funciona
- Se reutiliza el `multiSelect()` que ya existe en `ui.ts` (sin dependencias nuevas 🙌)
- `"universal"` siempre se incluye, no se muestra en el prompt
- Shortcut `[n] none` para deseleccionar todos rápido
- Si el usuario deselecciona todos los agentes, solo se usa `universal` con un mensaje informativo
## 📋 Cuándo NO aparece el prompt
| Situación               | Resultado                                                    |
| ----------------------- | ------------------------------------------------------------ |
| `-y` (auto-yes)           | Se salta el prompt, instala en todos (comportamiento actual) |
| `-a cursor claude-code`   | Usa los agentes pasados por flag, sin prompt                 |
| Solo 1 agente detectado | Se selecciona automáticamente                                |
| Non-TTY (CI/CD)         | Selecciona todos (comportamiento actual del `multiSelect`)     |
## 📁 Archivos modificados
Solo **un archivo**: `packages/autoskills/main.ts` (+45 líneas, -4 líneas)
- Nueva función `selectAgents()` — el prompt interactivo
- Se llama después de `selectSkills()` y antes de `installAll()`
- Los agentes seleccionados se pasan al installer y a la lógica de CLAUDE.md
## ✅ Tests
Los 55 tests existentes pasan sin cambios. No se agregaron tests nuevos porque la funcionalidad es interactiva (TTY) y los tests existentes cubren el dry-run y la detección de agentes.