### PR TITLE
feat(autoskills): add defaults skills field

### DIFF
--- a/packages/autoskills/lib.mjs
+++ b/packages/autoskills/lib.mjs
@@ -9,6 +9,7 @@ export {
   FRONTEND_BONUS_SKILLS,
   WEB_FRONTEND_EXTENSIONS,
   AGENT_FOLDER_MAP,
+  DEFAULT_SKILLS,
 } from "./skills-map.mjs";
 
 import {
@@ -18,6 +19,7 @@ import {
   FRONTEND_BONUS_SKILLS,
   WEB_FRONTEND_EXTENSIONS,
   AGENT_FOLDER_MAP,
+  DEFAULT_SKILLS,
 } from "./skills-map.mjs";
 
 // ── Internal Constants ───────────────────────────────────────
@@ -237,7 +239,7 @@ export function resolveWorkspaces(projectDir, preloaded) {
           (d) => resolve(d) !== resolve(projectDir),
         );
       }
-    } catch {}
+    } catch { }
   }
 
   const pkg = preloaded?.pkg !== undefined ? preloaded.pkg : readPackageJson(projectDir);
@@ -352,7 +354,7 @@ function detectTechnologiesInDir(
     let content = null;
     try {
       content = readFileSync(filePath, "utf-8");
-    } catch {}
+    } catch { }
     fileContentCache.set(filePath, content);
     if (content !== null) existsCache.set(filePath, true);
     return content;
@@ -537,6 +539,12 @@ export function collectSkills(detected, isFrontend, combos = []) {
     for (const skill of FRONTEND_BONUS_SKILLS) {
       addSkill(skill, "Frontend");
     }
+  }
+
+  // ── Default Skills ─────────────────────────────────────────
+
+  for (const skill of DEFAULT_SKILLS) {
+    addSkill(skill, "Default");
   }
 
   return skills;

--- a/packages/autoskills/skills-map.mjs
+++ b/packages/autoskills/skills-map.mjs
@@ -726,6 +726,13 @@ export const FRONTEND_BONUS_SKILLS = [
   "addyosmani/web-quality-skills/seo",
 ];
 
+// ── Default Skills ─────────────────────────────────────────
+
+export const DEFAULT_SKILLS = [
+  "juliusbrussee/caveman/caveman",
+];
+
+
 // ── Agent Folder Map ─────────────────────────────────────────
 
 /**

--- a/packages/autoskills/skills-map.mjs
+++ b/packages/autoskills/skills-map.mjs
@@ -438,7 +438,13 @@ export const SKILLS_MAP = [
     detect: {
       packages: ["express"],
     },
-    skills: [],
+    skills: [
+      "auth0/agent-skills/auth0-express",
+      "pluginagentmarketplace/custom-plugin-nodejs/express-rest-api",
+      "mindrally/skills/express-typescript",
+      "bobmatnyc/claude-mpm-skills/express-production",
+      "secondsky/claude-skills/zod"
+    ],
   },
   {
     id: "deno",

--- a/packages/autoskills/skills-map.mjs
+++ b/packages/autoskills/skills-map.mjs
@@ -472,11 +472,6 @@ export const SKILLS_MAP = [
       packages: ["express"],
     },
     skills: [
-      "auth0/agent-skills/auth0-express",
-      "pluginagentmarketplace/custom-plugin-nodejs/express-rest-api",
-      "mindrally/skills/express-typescript",
-      "bobmatnyc/claude-mpm-skills/express-production",
-      "secondsky/claude-skills/zod"
     ],
   },
   {

--- a/packages/autoskills/tests/collect.test.mjs
+++ b/packages/autoskills/tests/collect.test.mjs
@@ -1,11 +1,12 @@
 import { describe, it } from "node:test";
 import { ok, strictEqual, deepStrictEqual } from "node:assert/strict";
 import { collectSkills } from "../lib.mjs";
+import { DEFAULT_SKILLS } from "../skills-map.mjs";
 
 describe("collectSkills", () => {
-  it("returns empty array when no technologies detected", () => {
+  it("returns default skills when no technologies detected", () => {
     const skills = collectSkills([], false);
-    deepStrictEqual(skills, []);
+    deepStrictEqual(skills, DEFAULT_SKILLS.map(skill => ({ skill, sources: ["Default"] })));
   });
 
   it("collects skills from a single technology", () => {
@@ -18,7 +19,7 @@ describe("collectSkills", () => {
     ];
     const skills = collectSkills(detected, false);
 
-    strictEqual(skills.length, 1);
+    strictEqual(skills.length, 1 + DEFAULT_SKILLS.length);
     strictEqual(skills[0].skill, "vercel-labs/agent-skills/vercel-react-best-practices");
     deepStrictEqual(skills[0].sources, ["React"]);
   });
@@ -30,7 +31,7 @@ describe("collectSkills", () => {
     ];
     const skills = collectSkills(detected, false);
 
-    strictEqual(skills.length, 1);
+    strictEqual(skills.length, 1 + DEFAULT_SKILLS.length);
     strictEqual(skills[0].skill, "shared/repo/my-skill");
     deepStrictEqual(skills[0].sources, ["Tech A", "Tech B"]);
   });
@@ -46,7 +47,7 @@ describe("collectSkills", () => {
     ];
     const skills = collectSkills(detected, false);
 
-    strictEqual(skills.length, 2);
+    strictEqual(skills.length, 2 + DEFAULT_SKILLS.length);
     strictEqual(skills[0].skill, "vercel-labs/agent-skills/vercel-react-best-practices");
     strictEqual(skills[1].skill, "vercel-labs/next-skills/next-best-practices");
   });
@@ -61,7 +62,7 @@ describe("collectSkills", () => {
     ];
     const skills = collectSkills(detected, false);
 
-    strictEqual(skills.length, 2);
+    strictEqual(skills.length, 2 + DEFAULT_SKILLS.length);
     strictEqual(skills[0].skill, "hyf0/vue-skills/vue-best-practices");
     strictEqual(skills[1].skill, "antfu/skills/vue");
   });
@@ -102,6 +103,7 @@ describe("collectSkills", () => {
 
     const matches = skills.filter((s) => s.skill === "anthropics/skills/frontend-design");
     strictEqual(matches.length, 1);
+    strictEqual(skills.length, 3 + DEFAULT_SKILLS.length); // 3 Frontend Bonus skills + Default
   });
 
   it("skips technologies with empty skills", () => {
@@ -115,7 +117,7 @@ describe("collectSkills", () => {
     ];
     const skills = collectSkills(detected, false);
 
-    strictEqual(skills.length, 1);
+    strictEqual(skills.length, 1 + DEFAULT_SKILLS.length);
     strictEqual(skills[0].skill, "vercel-labs/agent-skills/vercel-react-best-practices");
   });
 
@@ -127,7 +129,7 @@ describe("collectSkills", () => {
     ];
     const skills = collectSkills(detected, false);
 
-    strictEqual(skills.length, 1);
+    strictEqual(skills.length, 1 + DEFAULT_SKILLS.length);
     deepStrictEqual(skills[0].sources, ["Tech A", "Tech B", "Tech C"]);
   });
 
@@ -142,7 +144,7 @@ describe("collectSkills", () => {
     ];
     const skills = collectSkills(detected, false, combos);
 
-    strictEqual(skills.length, 2);
+    strictEqual(skills.length, 2 + DEFAULT_SKILLS.length);
     ok(skills.some((s) => s.skill === "expo/skills/building-native-ui"));
     ok(skills.some((s) => s.skill === "expo/skills/expo-tailwind-setup"));
   });
@@ -158,7 +160,7 @@ describe("collectSkills", () => {
     ];
     const skills = collectSkills(detected, false, combos);
 
-    strictEqual(skills.length, 1);
+    strictEqual(skills.length, 1 + DEFAULT_SKILLS.length);
     strictEqual(skills[0].skill, "expo/skills/expo-tailwind-setup");
     ok(skills[0].sources.includes("Expo"));
     ok(skills[0].sources.includes("Expo + Tailwind CSS"));
@@ -177,7 +179,7 @@ describe("collectSkills", () => {
     ];
     const skills = collectSkills(detected, false, combos);
 
-    strictEqual(skills.length, 2);
+    strictEqual(skills.length, 2 + DEFAULT_SKILLS.length);
     ok(skills.some((s) => s.skill === "custom/repo/combo-skill"));
     const combo = skills.find((s) => s.skill === "custom/repo/combo-skill");
     deepStrictEqual(combo.sources, ["React + Custom"]);
@@ -209,7 +211,21 @@ describe("collectSkills", () => {
     ];
     const skills = collectSkills(detected, false, []);
 
-    strictEqual(skills.length, 1);
+    strictEqual(skills.length, 1 + DEFAULT_SKILLS.length);
     strictEqual(skills[0].skill, "vercel-labs/agent-skills/vercel-react-best-practices");
+  });
+
+  it("always includes DEFAULT_SKILLS perfectly even when other technologies are present", () => {
+    const detected = [
+      { id: "react", name: "React", skills: ["vercel-labs/agent-skills/vercel-react-best-practices"] },
+    ];
+    const skills = collectSkills(detected, false);
+    
+    strictEqual(skills.length, 1 + DEFAULT_SKILLS.length);
+    for (const defaultSkill of DEFAULT_SKILLS) {
+      ok(skills.some(s => s.skill === defaultSkill), `Missing default skill: ${defaultSkill}`);
+      const entry = skills.find(s => s.skill === defaultSkill);
+      ok(entry.sources.includes("Default"), `Source "Default" not assigned to: ${defaultSkill}`);
+    }
   });
 });


### PR DESCRIPTION
## What Changed

> [!WARNING]  
> Todas las pruebas se hicieron en bun

### 1. Extracción e Integración al Motor Core (`lib.mjs` y `skills-map.mjs`)
- Se importó `DEFAULT_SKILLS` globalmente.
- Se actualizó activamente la función central `collectSkills()` en `lib.mjs` para iterar e insertar todas las skills por defecto, sin importar si se detectó o no un entorno particular.
- Todo *Default Skill* se vinculó exitosamente a una etiqueta de procedencia customizada usando el valor `sources: ["Default"]`.
### 2. Visibilidad en el Componente Principal (`src/pages/index.astro`)
- Se implementó que los **Default Skills** aparezcan en la parte superior (por encima del `popularityOrder`).
- Para lograrlo sin corromper la maqueta, se construyó un objeto `defaultSkillsItem` que hereda el formato y componentes estilizados (Grid / Cards) que las demás herramientas, permitiendo renderizar dinámicamente estos datos en la sección web de *"Supported technologies & skills"*.
### 3. Fiabilidad en la Testing Suite (`tests/collect.test.mjs`)
- **Adaptación General de Asersiones:** Al inyectar skills obligatorios en `collectSkills()`, las pruebas estáticas fallaron por disonancia de longitudes. Se repararon cambiando aserciones estáticas por dinámicas (se sumó el valor dinámico `+ DEFAULT_SKILLS.length`).
- **Reparación del Test de Bonus Frontend:** Se corrigió un test que esperaba un resultado numéricamente incorrecto al asumir erróneamente en la aserción que `FRONTEND_BONUS_SKILLS` contenía 1 skill original en vez de la totalidad (la cual es de 3 skills).
- **Nuevas Pruebas Aisladas**:
  - `returns default skills when no technologies detected`: Nos aseguramos de que ejecutándose en un entorno o proyecto vacío el script garantice un retorno de las *default skills* integradas en vez de retornar un Array completamente vacío.
  - `always includes DEFAULT_SKILLS perfectly even when other technologies are present`: Se creó un nuevo test case totalmente aislado e independiente. Corrobora si cada skill de la lista por defecto sobrevive a la construcción normal de un stack simulado de herramientas anexadas (como `React`), reafirmando también la integridad de la asignación del origin tag de `"Default"`.

## Why This Change

### Necesidad de tener skills en todos los proyectos
Hice este cambio para que, **por defecto**, en cualquier proyecto el usuario tenga acceso a herramientas globales como **[Caveman](https://juliusbrussee.github.io/caveman/)** y otras herramientas de uso general.

## Testing Done

<!-- Describe the testing you performed to validate your changes -->

- [x] Manual testing completed
- [x] Automated tests pass locally
- [x] Edge cases considered and tested

## Type of Change

- [ ] `fix:` Bug fix
- [x] `feat:` New feature
- [ ] `refactor:` Code refactoring
- [ ] `docs:` Documentation
- [ ] `test:` Tests
- [ ] `chore:` Maintenance/tooling

## Security & Quality Checklist

- [x] No secrets or API keys committed
- [x] Follows the project's coding standards
- [x] No sensitive data exposed in logs or output

## Documentation

- [ ] Updated relevant documentation
- [ ] Added comments for complex logic
- [x] README updated (if needed)

## Photos

### Web default preview:
<img width="554" height="213" alt="2026-04-15-200820_hyprshot" src="https://github.com/user-attachments/assets/b96c382f-5194-4fb8-be21-222f1c65537a" />

### When the packages in running:
<img width="767" height="753" alt="2026-04-15-201216_hyprshot" src="https://github.com/user-attachments/assets/985cab0b-5527-4ac7-9b93-1116dd9afa8d" />

###Test:
<img width="999" height="631" alt="2026-04-15-200936_hyprshot" src="https://github.com/user-attachments/assets/8cd6b88d-2e7c-4d22-89be-4e30dd96e722" />

##When the skills is installed:
<img width="764" height="416" alt="2026-04-15-202513_hyprshot" src="https://github.com/user-attachments/assets/d8d272d4-60e4-4070-87ba-7d190d091c8d" />




