### PR TITLE
fix: detect configFiles in subdirectories with deep scan fallback

### DIFF
--- a/packages/autoskills/lib.ts
+++ b/packages/autoskills/lib.ts
@@ -344,6 +344,37 @@ export function resolveWorkspaces(projectDir: string, preloaded?: PreloadedManif
 
 // ── Detection ─────────────────────────────────────────────────
 
+export function existsDeep(
+  dir: string,
+  fileNames: string[],
+  maxDepth: number = 3,
+): boolean {
+  const nameSet = new Set(fileNames);
+
+  function scan(current: string, depth: number): boolean {
+    let entries: import("node:fs").Dirent[];
+    try {
+      entries = readdirSync(current, { withFileTypes: true });
+    } catch {
+      return false;
+    }
+    for (const entry of entries) {
+      if (entry.isFile() && nameSet.has(entry.name)) return true;
+      if (
+        entry.isDirectory() &&
+        depth < maxDepth &&
+        !entry.name.startsWith(".") &&
+        !SCAN_SKIP_DIRS.has(entry.name)
+      ) {
+        if (scan(join(current, entry.name), depth + 1)) return true;
+      }
+    }
+    return false;
+  }
+
+  return scan(dir, 0);
+}
+
 export function readGemfile(dir: string): string[] {
   const gemfilePath = join(dir, "Gemfile");
   if (!existsSync(gemfilePath)) return [];
@@ -468,6 +499,9 @@ function detectTechnologiesInDir(
 
     if (!found && tech.detect.configFiles) {
       found = tech.detect.configFiles.some((f) => cachedExists(join(dir, f)));
+      if (!found) {
+        found = existsDeep(dir, tech.detect.configFiles);
+      }
     }
 
     if (!found && tech.detect.gems) {

--- a/packages/autoskills/tests/detect.test.ts
+++ b/packages/autoskills/tests/detect.test.ts
@@ -9,6 +9,7 @@ import {
   detectTechnologies,
   detectCombos,
   parseSettingsGradleModules,
+  existsDeep,
 } from "../lib.ts";
 import { useTmpDir, writePackageJson, writeJson, writeFile, addWorkspace } from "./helpers.ts";
 
@@ -1631,5 +1632,74 @@ describe("detectCombos", () => {
 
   it("does not detect rails-rspec combo without rspec", () => {
     ok(!detectCombos(["rails"]).some((c) => c.id === "rails-rspec"));
+  });
+});
+
+// ── existsDeep ───────────────────────────────────────────────
+
+describe("existsDeep", () => {
+  const tmp = useTmpDir();
+
+  it("finds a file at the root level", () => {
+    writeFile(tmp.path, "Package.swift", "");
+    ok(existsDeep(tmp.path, ["Package.swift"]));
+  });
+
+  it("finds a file one level deep", () => {
+    writeFile(tmp.path, "Packages/DesignSystem/Package.swift", "");
+    ok(existsDeep(tmp.path, ["Package.swift"]));
+  });
+
+  it("finds a file two levels deep", () => {
+    writeFile(tmp.path, "ios/App/Podfile", "");
+    ok(existsDeep(tmp.path, ["Podfile"]));
+  });
+
+  it("returns false when file is absent", () => {
+    ok(!existsDeep(tmp.path, ["Package.swift", "Podfile"]));
+  });
+
+  it("returns false when file exceeds maxDepth", () => {
+    writeFile(tmp.path, "a/b/c/d/Package.swift", "");
+    ok(!existsDeep(tmp.path, ["Package.swift"], 3));
+  });
+
+  it("skips node_modules directories", () => {
+    writeFile(tmp.path, "node_modules/some-pkg/Package.swift", "");
+    ok(!existsDeep(tmp.path, ["Package.swift"]));
+  });
+
+  it("matches any name from the provided list", () => {
+    writeFile(tmp.path, "ios/Podfile", "");
+    ok(existsDeep(tmp.path, ["Package.swift", "Podfile"]));
+  });
+});
+
+// ── detectTechnologies — configFiles deep scan (SwiftUI) ──────
+
+describe("detectTechnologies — configFiles deep scan (SwiftUI)", () => {
+  const tmp = useTmpDir();
+
+  it("detects swiftui when Package.swift is at root", () => {
+    writeFile(tmp.path, "Package.swift", "");
+    const { detected } = detectTechnologies(tmp.path);
+    ok(detected.some((t) => t.id === "swiftui"));
+  });
+
+  it("detects swiftui when Package.swift is in a subdirectory (e.g. Packages/)", () => {
+    writeFile(tmp.path, "Packages/DesignSystem/Package.swift", "");
+    const { detected } = detectTechnologies(tmp.path);
+    ok(detected.some((t) => t.id === "swiftui"));
+  });
+
+  it("detects swiftui when Podfile is nested under ios/", () => {
+    writeFile(tmp.path, "ios/Podfile", "");
+    const { detected } = detectTechnologies(tmp.path);
+    ok(detected.some((t) => t.id === "swiftui"));
+  });
+
+  it("does not detect swiftui when neither Package.swift nor Podfile exist", () => {
+    const { detected } = detectTechnologies(tmp.path);
+    ok(!detected.some((t) => t.id === "swiftui"));
   });
 });


### PR DESCRIPTION
## What Changed

Added `existsDeep()` to `lib.ts` — a recursive directory scanner that serves as an automatic fallback when the root-level `configFiles` check misses.

Updated `detectTechnologiesInDir()` so that `configFiles` detection now:
1. Checks the project root first (fast, existing behaviour)
2. If missed, falls back to a deep scan up to 3 directory levels, skipping `node_modules`, `.git`, `Pods`, etc.

No changes to `skills-map.ts` entries or the public API — existing config just works.

## Why This Change

`configFiles` detection previously called `existsSync(join(dir, fileName))`, which only checks the **project root**. This silently missed real-world Apple platform projects where `Package.swift` or `Podfile` live in a subdirectory:

| Project type | File location | Before | After |
|---|---|---|---|
| CocoaPods iOS (repo root = parent folder) | `ProjectName/Podfile` | ❌ not detected | ✅ swiftui |
| React Native | `ios/Podfile` | ❌ not detected | ✅ swiftui |
| SPM sub-package | `Packages/DesignSystem/Package.swift` | ❌ not detected | ✅ swiftui |
| Standard SPM project | `Package.swift` (root) | ✅ works | ✅ works |

## Testing Done

- [x] 343/343 tests pass (`node --test 'tests/*.test.ts'`)
- [x] 11 new tests added: `existsDeep` unit tests + SwiftUI deep-detection integration tests
- [x] Verified against 2 real CocoaPods projects (SkillCare, Jumper) at all nesting depths

```
Path: /ProjectRoot              → Detected: [swiftui, ruby] ✅
Path: /ProjectRoot/ProjectName  → Detected: [swiftui, ruby] ✅
Path: /ProjectRoot/ProjectName/ProjectName (Podfile at root) → Detected: [swiftui, ruby] ✅
```

## Type of Change

- [x] `fix:` Bug fix (non-breaking — no API or config changes)

## Security & Quality Checklist

- [x] No secrets or API keys committed
- [x] Follows the project's coding standards
- [x] No sensitive data exposed in logs or output

## Documentation

No documentation changes needed — this is an internal detection improvement with no public API changes.