### PR TITLE
fix(skills-map): remove duplicate flask entry with empty skills array

### DIFF
--- a/packages/autoskills/skills-map.ts
+++ b/packages/autoskills/skills-map.ts
@@ -1009,17 +1009,6 @@ export const SKILLS_MAP: Technology[] = [
     ],
   },
   {
-    id: "flask",
-    name: "Flask",
-    detect: {
-      configFileContent: {
-        files: ["pyproject.toml", "requirements.txt", "setup.py", "setup.cfg", "Pipfile"],
-        patterns: ["flask", "Flask"],
-      },
-    },
-    skills: [],
-  },
-  {
     id: "python",
     name: "Python",
     detect: {
@@ -1062,7 +1051,7 @@ export const SKILLS_MAP: Technology[] = [
     name: "Flask",
     detect: {
       configFileContent: {
-        files: ["pyproject.toml", "requirements.txt", "setup.py", "Pipfile"],
+        files: ["pyproject.toml", "requirements.txt", "setup.py", "setup.cfg", "Pipfile"],
         patterns: ["flask", "Flask"],
       },
     },


### PR DESCRIPTION
## What Changed

Removed a duplicate `flask` entry in `SKILLS_MAP` that had an empty `skills` array.

## Root Cause

There were two entries with `id: "flask"` in `skills-map.ts`:
- **First entry** (broken): `skills: []`, included `setup.cfg` in detection files
- **Second entry** (correct): had the actual skills but missing `setup.cfg`

Since `detectTechnologiesInDir` iterates `SKILLS_MAP` in order and pushes every match, both entries were detected. The first empty one caused Flask projects to receive no skills — the bug reported in #90.

## Fix
- Removed the duplicate entry with `skills: []`
- Added `setup.cfg` to detection files of the correct entry

Closes #90