### PR TITLE
issue: #100 - fix web mobile responsive overflow

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -139,7 +139,7 @@ const skillsMap = [...SKILLS_MAP].sort((a: any, b: any) => {
   <main class="text-sm leading-relaxed px-6 py-12 lg:w-1/2 lg:pl-12 lg:pr-8 lg:py-16">
 
     <!-- ASCII Logo (animated reveal) -->
-    <pre id="ascii-logo" class="text-[clamp(5.5px,calc((100vw-48px)/50),10px)] sm:text-xs lg:text-[9px] leading-none mb-8 h-[6lh] overflow-hidden" aria-hidden="true"></pre>
+    <pre id="ascii-logo" class="text-[6px] sm:text-xs lg:text-[9px] leading-none mb-8 h-[6lh] overflow-hidden" aria-hidden="true"></pre>
 
     <h1 class="text-zinc-400 mb-8">
       Auto-detect your tech stack and install the best<br/>
@@ -179,7 +179,7 @@ const skillsMap = [...SKILLS_MAP].sort((a: any, b: any) => {
     </div>
 
     <!-- Separator -->
-    <div class="text-zinc-700 mb-12">{'─'.repeat(48)}</div>
+    <div class="mb-12 h-0.5 w-full bg-zinc-700"></div>
 
     <!-- How it works -->
     <div class="mb-12">
@@ -210,7 +210,7 @@ const skillsMap = [...SKILLS_MAP].sort((a: any, b: any) => {
     </div>
 
     <!-- Separator -->
-    <div class="text-zinc-700 mb-12">{'─'.repeat(48)}</div>
+    <div class="mb-12 h-0.5 w-full bg-zinc-700"></div>
 
     <!-- Options -->
     <div class="mb-12">
@@ -240,7 +240,7 @@ const skillsMap = [...SKILLS_MAP].sort((a: any, b: any) => {
     </div>
 
     <!-- Separator -->
-    <div class="text-zinc-700 mb-12">{'─'.repeat(48)}</div>
+    <div class="mb-12 h-0.5 w-full bg-zinc-700"></div>
 
     <!-- Supported Technologies & Skills -->
     <div class="mb-12">
@@ -281,7 +281,7 @@ const skillsMap = [...SKILLS_MAP].sort((a: any, b: any) => {
     </div>
 
     <!-- Separator -->
-    <div class="text-zinc-700 mb-12">{'─'.repeat(48)}</div>
+    <div class="mb-12 h-0.5 w-full bg-zinc-700"></div>
 
     <!-- Footer -->
     <footer class="text-zinc-600 space-y-4 pb-8">


### PR DESCRIPTION
## What Changed

 - Updated the ASCII logo size on mobile from a dynamic `clamp(...)` value to a fixed `text-[6px]` to prevent layout/overflow issues
 on narrow screens.
 - Replaced text-based separators (`{'─'.repeat(48)}`) with responsive full-width divider elements (`<div class="mb-12 h-0.5 w-full
bg-zinc-700"></div>`).

 ## Why This Change

 The homepage had mobile responsiveness issues where fixed-character separators and the dynamic ASCII logo sizing could cause overflow

 ## Testing Done

 - No automated test changes were included in this commit (UI/layout-only update).

 - [ ] Manual testing completed
 - [ ] Automated tests pass locally
 - [ ] Edge cases considered and tested

 ## Type of Change

 - [x] `fix:` Bug fix
 - [ ] `feat:` New feature
 - [ ] `refactor:` Code refactoring
 - [ ] `docs:` Documentation
 - [ ] `test:` Tests
 - [ ] `chore:` Maintenance/tooling

 ## Security & Quality Checklist

 - [x] No secrets or API keys committed
 - [x] Follows the project's coding standards
 - [x] No sensitive data exposed in logs or output

 ## Documentation

 - [ ] Updated relevant documentation
 - [ ] Added comments for complex logic
 - [ ] README updated (if needed)

you can see the screen sizes in the screenshots

before: 
<img width="471" height="1006" alt="image" src="https://github.com/user-attachments/assets/31ba3ef2-ceb9-4fe7-a54e-2b5a67a9c4d4" />

now:
<img width="449" height="1013" alt="image" src="https://github.com/user-attachments/assets/0bcaefe5-58e8-43d0-8315-e9168cb837ee" />

