### PR TITLE
fix(release): normalize repository URL for changelog and release summary links

### DIFF
--- a/packages/autoskills/scripts/release.mjs
+++ b/packages/autoskills/scripts/release.mjs
@@ -14,6 +14,45 @@ const CHANGELOG_PATH = resolve(ROOT, "CHANGELOG.md");
 const VALID_BUMPS = ["patch", "minor", "major"];
 
 /**
+ * Normalizes repository URLs to a browser-safe HTTPS GitHub URL.
+ * Supports git+https, SSH (git@github.com:owner/repo), and ssh://git@ URLs.
+ * Falls back to the project default when input is missing or invalid.
+ * @param {string | undefined} rawUrl
+ * @returns {string}
+ */
+function normalizeRepoUrl(rawUrl) {
+  const fallback = "https://github.com/midudev/autoskills";
+  if (!rawUrl || typeof rawUrl !== "string") return fallback;
+
+  let url = rawUrl.trim();
+
+  // Convert git+https://... -> https://...
+  if (url.startsWith("git+https://")) {
+    url = url.replace(/^git\+/, "");
+  }
+
+  // Convert git@github.com:owner/repo(.git)? -> https://github.com/owner/repo
+  if (/^git@github\.com:/.test(url)) {
+    url = url.replace(/^git@github\.com:/, "https://github.com/");
+  }
+
+  // Convert ssh://git@github.com/owner/repo(.git)? -> https://github.com/owner/repo
+  if (/^ssh:\/\/git@github\.com\//.test(url)) {
+    url = url.replace(/^ssh:\/\/git@github\.com\//, "https://github.com/");
+  }
+
+  // Remove trailing .git and trailing slash
+  url = url.replace(/\.git$/, "").replace(/\/+$/, "");
+
+  // Allow only http/https browser-safe URLs
+  if (!/^https?:\/\//.test(url)) {
+    return fallback;
+  }
+
+  return url;
+}
+
+/**
  * Executes a shell command synchronously and returns its trimmed stdout.
  * @param {string} cmd - Command to run.
  * @param {import('node:child_process').ExecSyncOptions} [opts]
@@ -194,8 +233,7 @@ if (!bump || !VALID_BUMPS.includes(bump)) {
 }
 
 const pkg = JSON.parse(readFileSync(PKG_PATH, "utf-8"));
-const repoUrl =
-  pkg.repository?.url?.replace(/\.git$/, "") || "https://github.com/midudev/autoskills";
+const repoUrl = normalizeRepoUrl(pkg.repository?.url);
 const currentVersion = pkg.version;
 const newVersion = bumpVersion(currentVersion, bump);
 const originalPkgContent = readFileSync(PKG_PATH, "utf-8");


### PR DESCRIPTION
## What Changed

- Added repository URL normalization logic in `packages/autoskills/scripts/release.mjs` so changelog and release-summary links are browser-safe.
- Normalized non-web Git URL formats to HTTPS before generating markdown links:
  - `git+https://...`
  - `git@github.com:owner/repo`
  - `ssh://git@github.com/owner/repo`
- Kept fallback behavior to the default repository URL when `repository.url` is missing or invalid.

## Why This Change

- Changelog/release links were being generated from raw Git repository URLs.
- Some formats (especially `git+https://`) are not consistently recognized as clickable links by markdown renderers.
- Normalizing to `https://` ensures commit and release links render correctly in changelog entries and release summaries.

## Testing Done

<!-- Describe the testing you performed to validate your changes -->

- [x] Manual testing completed
- [ ] Automated tests pass locally
- [x] Edge cases considered and tested

## Type of Change

- [x] `fix:` Bug fix
- [ ] `feat:` New feature
- [ ] `refactor:` Code refactoring
- [ ] `docs:` Documentation
- [ ] `test:` Tests
- [ ] `chore:` Maintenance/tooling

## Security & Quality Checklist

- [x] No secrets or API keys committed
- [x] Follows the project's coding standards
- [x] No sensitive data exposed in logs or output

## Documentation

- [ ] Updated relevant documentation
- [x] Added comments for complex logic
- [ ] README updated (if needed)
