### PR TITLE
feat: add C/C++/Qt ecosystem skills to autoskills registry

### DIFF
--- a/packages/autoskills/skills-map.ts
+++ b/packages/autoskills/skills-map.ts
@@ -684,7 +684,7 @@ export const SKILLS_MAP: Technology[] = [
     detect: {
       configFiles: ["CMakeLists.txt"],
       configFileContent: {
-        patterns: ["find_package(GTest", "GTest::gtest", "FetchContent.*googletest", "gtest", "gmock"],
+        patterns: ["find_package(GTest", "GTest::gtest", "GTest::gmock", "FetchContent.*googletest"],
         files: ["CMakeLists.txt"],
       },
     },

--- a/packages/autoskills/skills-map.ts
+++ b/packages/autoskills/skills-map.ts
@@ -619,6 +619,86 @@ export const SKILLS_MAP: Technology[] = [
     skills: ["wshobson/agents/bash-defensive-patterns"],
   },
   {
+    id: "c",
+    name: "C",
+    detect: {
+      fileExtensions: [".c"],
+    },
+    skills: ["autoskills/c"],
+  },
+  {
+    id: "cpp",
+    name: "C++",
+    detect: {
+      fileExtensions: [".cpp", ".cxx", ".cc", ".hpp", ".hxx"],
+    },
+    skills: ["autoskills/cpp"],
+  },
+  {
+    id: "cmake",
+    name: "CMake",
+    detect: {
+      configFiles: ["CMakeLists.txt"],
+    },
+    skills: ["autoskills/cmake"],
+  },
+  {
+    id: "qt",
+    name: "Qt",
+    detect: {
+      fileExtensions: [".qml"],
+      configFileContent: {
+        patterns: ["find_package(Qt6", "find_package(Qt5", "QT +=", "qt_add_executable"],
+        files: ["CMakeLists.txt", "*.pro"],
+      },
+    },
+    skills: ["autoskills/qt"],
+  },
+  {
+    id: "conan",
+    name: "Conan",
+    detect: {
+      configFiles: ["conanfile.txt", "conanfile.py"],
+    },
+    skills: ["autoskills/conan"],
+  },
+  {
+    id: "vcpkg",
+    name: "vcpkg",
+    detect: {
+      configFiles: ["vcpkg.json"],
+    },
+    skills: ["autoskills/vcpkg"],
+  },
+  {
+    id: "meson",
+    name: "Meson",
+    detect: {
+      configFiles: ["meson.build"],
+    },
+    skills: ["autoskills/meson"],
+  },
+  {
+    id: "googletest",
+    name: "Google Test",
+    detect: {
+      configFiles: ["CMakeLists.txt"],
+      configFileContent: {
+        patterns: ["find_package(GTest", "GTest::gtest", "FetchContent.*googletest", "gtest", "gmock"],
+        files: ["CMakeLists.txt"],
+      },
+    },
+    skills: ["autoskills/googletest"],
+  },
+  {
+    id: "doxygen",
+    name: "Doxygen",
+    detect: {
+      configFiles: ["Doxyfile", "Doxyfile.in"],
+    },
+    skills: ["autoskills/doxygen"],
+  },
+  {
     id: "express",
     name: "Express",
     detect: {

--- a/packages/autoskills/skills-registry/c/SKILL.md
+++ b/packages/autoskills/skills-registry/c/SKILL.md
@@ -1,0 +1,167 @@
+---
+name: c
+description: "Build systems programming projects in C. Use when writing C code, debugging memory issues, working with Makefiles/CMake, managing headers, or building libraries and executables. Covers C11/C17/C23 standards, POSIX, and common patterns."
+metadata:
+  version: "1.0"
+  source: "autoskills"
+---
+
+# C Programming
+
+## When to Use
+
+- Writing or reviewing C source code (`.c` / `.h` files)
+- Debugging memory management (malloc/free, buffer overflows, leaks)
+- Working with Makefiles or CMake build systems
+- Building shared/static libraries
+- POSIX system programming (file I/O, processes, threads, sockets)
+- Embedded or bare-metal development
+- Interfacing with hardware or OS APIs
+
+## Quick Reference
+
+### Compilation
+
+| Task | Command | Notes |
+|------|---------|-------|
+| Compile single file | `gcc -o out file.c` | Default C standard |
+| Specify standard | `gcc -std=c17 -o out file.c` | C11, C17, C23 |
+| Enable warnings | `gcc -Wall -Wextra -Werror -o out file.c` | Treat warnings as errors |
+| Debug build | `gcc -g -fsanitize=address -o out file.c` | ASan for memory errors |
+| Optimize | `gcc -O2 -o out file.c` | Production build |
+| Link math lib | `gcc -o out file.c -lm` | Required for `<math.h>` |
+| Compile only | `gcc -c file.c` | Produces `file.o` |
+
+### Common Flags
+
+| Flag | Purpose |
+|------|---------|
+| `-Wall -Wextra` | Enable most warnings |
+| `-Werror` | Treat warnings as errors |
+| `-fsanitize=address` | AddressSanitizer (memory errors) |
+| `-fsanitize=undefined` | UndefinedBehaviorSanitizer |
+| `-fsanitize=thread` | ThreadSanitizer (data races) |
+| `-pedantic` | Strict ISO compliance |
+| `-std=c17` | Use C17 standard |
+| `-std=c23` | Use C23 standard (latest) |
+| `-I/dir` | Add include path |
+| `-L/dir` | Add library search path |
+| `-l[name]` | Link library (e.g., `-lpthread`) |
+
+## Memory Management
+
+```c
+// Allocate
+int *arr = malloc(n * sizeof(int));
+if (!arr) { /* handle error */ }
+
+// Reallocate
+arr = realloc(arr, new_size * sizeof(int));
+
+// Free
+free(arr);
+arr = NULL;  // Avoid dangling pointer
+```
+
+### Valgrind
+
+```bash
+valgrind --leak-check=full --track-origins=yes ./program
+```
+
+## Common Patterns
+
+### Header Guard
+
+```c
+#ifndef MYHEADER_H
+#define MYHEADER_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* declarations */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* MYHEADER_H */
+```
+
+### Makefile
+
+```makefile
+CC = gcc
+CFLAGS = -Wall -Wextra -std=c17 -g
+LDFLAGS =
+SRCS = $(wildcard *.c)
+OBJS = $(SRCS:.c=.o)
+TARGET = program
+
+all: $(TARGET)
+
+$(TARGET): $(OBJS)
+	$(CC) $(LDFLAGS) -o $@ $^
+
+%.o: %.c
+	$(CC) $(CFLAGS) -c -o $@ $<
+
+clean:
+	rm -f $(OBJS) $(TARGET)
+
+.PHONY: all clean
+```
+
+### Static Library
+
+```bash
+gcc -c file1.c file2.c
+ar rcs libmylib.a file1.o file2.o
+gcc -o program main.c -L. -lmylib
+```
+
+### Shared Library
+
+```bash
+gcc -shared -fPIC -o libmylib.so file1.c file2.c
+gcc -o program main.c -L. -lmylib -Wl,-rpath,.
+```
+
+## Common Gotchas
+
+- Always check `malloc`/`calloc` return values for `NULL`
+- Never use `gets()` — use `fgets()` instead
+- Free memory in the same order it was allocated if using complex dependency chains
+- Use `size_t` for sizes and indices, not `int`
+- Initialize all variables before use
+- Use `const` for read-only parameters
+- Watch for integer overflow in `malloc(n * size)` — check for `SIZE_MAX / size < n`
+- Use `snprintf()` instead of `sprintf()` to prevent buffer overflow
+- Null-terminate strings properly
+
+## Debugging
+
+```bash
+# GDB basics
+gcc -g -o program program.c
+gdb ./program
+
+# Inside GDB
+(gdb) break main
+(gdb) run
+(gdb) next        # Step over
+(gdb) step        # Step into
+(gdb) print var   # Inspect variable
+(gdb) backtrace   # Call stack
+```
+
+## Verification Checklist
+
+- [ ] Compiled with `-Wall -Wextra` and no warnings
+- [ ] No memory leaks (verified with Valgrind or ASan)
+- [ ] All `malloc`/`calloc` returns checked
+- [ ] No use of deprecated/unsafe functions (`gets`, `strcpy` without bounds)
+- [ ] Header guards present in all `.h` files
+- [ ] Return values of system calls checked

--- a/packages/autoskills/skills-registry/c/SKILL.md
+++ b/packages/autoskills/skills-registry/c/SKILL.md
@@ -55,8 +55,11 @@ metadata:
 int *arr = malloc(n * sizeof(int));
 if (!arr) { /* handle error */ }
 
-// Reallocate
-arr = realloc(arr, new_size * sizeof(int));
+// Reallocate: use temporary to preserve original on failure
+if (new_size > SIZE_MAX / sizeof(int)) { /* handle overflow */ }
+void *tmp = realloc(arr, new_size * sizeof(int));
+if (tmp) arr = tmp;
+else     { /* handle failure — arr still valid */ }
 
 // Free
 free(arr);
@@ -126,14 +129,15 @@ gcc -o program main.c -L. -lmylib
 
 ```bash
 gcc -shared -fPIC -o libmylib.so file1.c file2.c
-gcc -o program main.c -L. -lmylib -Wl,-rpath,.
+gcc -o program main.c -L. -lmylib -Wl,-rpath,'$ORIGIN'
+# Only use $ORIGIN when libraries are distributed alongside the executable
 ```
 
 ## Common Gotchas
 
 - Always check `malloc`/`calloc` return values for `NULL`
 - Never use `gets()` — use `fgets()` instead
-- Free memory in the same order it was allocated if using complex dependency chains
+- Free memory in dependency order: release dependent objects before their owning containers
 - Use `size_t` for sizes and indices, not `int`
 - Initialize all variables before use
 - Use `const` for read-only parameters

--- a/packages/autoskills/skills-registry/cmake/SKILL.md
+++ b/packages/autoskills/skills-registry/cmake/SKILL.md
@@ -141,6 +141,7 @@ endif()
 include(GNUInstallDirs)
 
 install(TARGETS mylib
+    EXPORT mylib-config
     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
 )

--- a/packages/autoskills/skills-registry/cmake/SKILL.md
+++ b/packages/autoskills/skills-registry/cmake/SKILL.md
@@ -1,0 +1,188 @@
+---
+name: cmake
+description: "Build and configure C/C++ projects with CMake. Use when writing CMakeLists.txt, managing dependencies with find_package or FetchContent, setting up build configurations, cross-compiling, or working with modern CMake targets and properties."
+metadata:
+  version: "1.0"
+  source: "autoskills"
+---
+
+# CMake Build System
+
+## When to Use
+
+- Writing or maintaining `CMakeLists.txt` files
+- Managing C/C++ dependencies (`find_package`, `FetchContent`, `Conan`, `vcpkg`)
+- Setting up build types (Debug, Release, RelWithDebInfo)
+- Cross-compilation and toolchain files
+- Testing with `CTest`
+- Packaging with `CPack`
+- Modern CMake target-based configuration
+
+## Quick Reference
+
+### Essential Commands
+
+| Task | Command | Notes |
+|------|---------|-------|
+| Configure | `cmake -B build -S .` | Out-of-source build |
+| Build | `cmake --build build` | Compile the project |
+| Clean rebuild | `cmake --build build --clean-first` | Clean + build |
+| Install | `cmake --install build` | Install to prefix |
+| Run tests | `ctest --test-dir build` | After build |
+| List generators | `cmake --help` | Shows available generators |
+
+### Build Types
+
+| Type | Flags | Use Case |
+|------|-------|----------|
+| `Debug` | `-g -O0` | Development |
+| `Release` | `-O3 -DNDEBUG` | Production |
+| `RelWithDebInfo` | `-O2 -g -DNDEBUG` | Profiling |
+| `MinSizeRel` | `-Os -DNDEBUG` | Size-constrained |
+
+```bash
+cmake -B build -DCMAKE_BUILD_TYPE=Release
+```
+
+## CMakeLists.txt Patterns
+
+### Minimum Project
+
+```cmake
+cmake_minimum_required(VERSION 3.16)
+project(MyApp VERSION 1.0 LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+add_executable(myapp main.cpp)
+target_link_libraries(myapp PRIVATE some::lib)
+```
+
+### Library + Executable
+
+```cmake
+cmake_minimum_required(VERSION 3.16)
+project(MyProject LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+# Library
+add_library(mylib STATIC
+    src/mylib.cpp
+    src/mylib_internal.cpp
+)
+target_include_directories(mylib PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>
+)
+
+# Executable
+add_executable(myapp main.cpp)
+target_link_libraries(myapp PRIVATE mylib)
+```
+
+### Finding Dependencies
+
+```cmake
+# Standard find_package
+find_package(Qt6 REQUIRED COMPONENTS Core Widgets)
+target_link_libraries(myapp PRIVATE Qt6::Core Qt6::Widgets)
+
+# FetchContent (download at configure time)
+include(FetchContent)
+FetchContent_Declare(
+    fmt
+    GIT_REPOSITORY https://github.com/fmtlib/fmt.git
+    GIT_TAG 10.2.1
+)
+FetchContent_MakeAvailable(fmt)
+target_link_libraries(myapp PRIVATE fmt::fmt)
+```
+
+### Testing
+
+```cmake
+enable_testing()
+find_package(GTest REQUIRED)
+
+add_executable(tests test_main.cpp test_mylib.cpp)
+target_link_libraries(tests PRIVATE GTest::gtest_main mylib)
+
+include(GoogleTest)
+gtest_discover_tests(tests)
+```
+
+### Options and Conditionals
+
+```cmake
+option(BUILD_TESTS "Build tests" ON)
+option(BUILD_SHARED_LIBS "Build shared libraries" OFF)
+
+if(BUILD_TESTS)
+    enable_testing()
+    add_subdirectory(tests)
+endif()
+
+# Platform checks
+if(WIN32)
+    target_compile_definitions(mylib PRIVATE PLATFORM_WINDOWS)
+elseif(APPLE)
+    target_compile_definitions(mylib PRIVATE PLATFORM_MACOS)
+elseif(UNIX)
+    target_compile_definitions(mylib PRIVATE PLATFORM_LINUX)
+endif()
+```
+
+### Install Rules
+
+```cmake
+include(GNUInstallDirs)
+
+install(TARGETS mylib
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+)
+
+install(DIRECTORY include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+
+# CMake package config
+install(EXPORT mylib-config
+    NAMESPACE mylib::
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/mylib
+)
+```
+
+## Best Practices
+
+- Use **target-based** commands (`target_link_libraries`, `target_compile_options`) instead of global (`link_libraries`, `add_compile_options`)
+- Use `PRIVATE`, `PUBLIC`, `INTERFACE` visibility correctly on `target_link_libraries`
+- Use generator expressions for build/install interfaces: `$<BUILD_INTERFACE:...>` / `$<INSTALL_INTERFACE:...>`
+- Use `CMAKE_CXX_STANDARD` instead of compiler flags for C++ standard
+- Always use `CMAKE_CXX_STANDARD_REQUIRED ON`
+- Use `FetchContent` for vendored dependencies, `find_package` for system deps
+- Use `CMAKE_EXPORT_COMPILE_COMMANDS ON` for IDE/editor integration
+- Use `configure_file()` for config headers instead of `add_definitions`
+- Set minimum CMake version to 3.16+ (supports modern features)
+
+## Common Gotchas
+
+- Out-of-source builds: always use `-B build` (never build in source root)
+- `CMAKE_BUILD_TYPE` is single-config generators only (Makefiles, Ninja)
+- Multi-config generators (Visual Studio, Xcode) set build type at build time
+- `FetchContent` downloads at configure time — pin specific tags/commits
+- `find_package` vs `find_package(... CONFIG)`: CONFIG mode uses package config files
+- Variable scope: use `PARENT_SCOPE` or `CACHE` when needed
+- Use `${CMAKE_CURRENT_SOURCE_DIR}` not `${CMAKE_SOURCE_DIR}` in subdirectories
+- `CMAKE_INSTALL_PREFIX` controls install location (default `/usr/local`)
+
+## Verification Checklist
+
+- [ ] Uses target-based commands (not global)
+- [ ] `CMAKE_CXX_STANDARD_REQUIRED ON` set
+- [ ] Dependencies pinned to specific versions
+- [ ] Build tests with `enable_testing()` + `ctest`
+- [ ] Install rules use `GNUInstallDirs` variables
+- [ ] No in-source builds
+- [ ] `compile_commands.json` generated for IDE support

--- a/packages/autoskills/skills-registry/conan/SKILL.md
+++ b/packages/autoskills/skills-registry/conan/SKILL.md
@@ -85,10 +85,9 @@ class MyPkgConan(ConanFile):
         cmake = CMake(self)
         cmake.install()
         copy(self, "*.h", src=self.source_folder, dst=os.path.join(self.package_folder, "include"))
-        collect_libs(self)
 
     def package_info(self):
-        self.cpp_info.libs = ["mypkg"]
+        self.cpp_info.libs = collect_libs(self)
 ```
 
 ## CMake Integration

--- a/packages/autoskills/skills-registry/conan/SKILL.md
+++ b/packages/autoskills/skills-registry/conan/SKILL.md
@@ -1,0 +1,158 @@
+---
+name: conan
+description: "Manage C/C++ dependencies with Conan package manager. Use when adding, removing, or updating libraries, creating conanfile.txt or conanfile.py, configuring remotes, or resolving dependency conflicts in C/C++ projects."
+metadata:
+  version: "1.0"
+  source: "autoskills"
+---
+
+# Conan Package Manager
+
+## When to Use
+
+- Adding third-party C/C++ libraries to a project
+- Managing dependency versions and configurations
+- Creating reusable package recipes
+- Configuring package remotes and mirrors
+- Resolving transitive dependency conflicts
+- Cross-compiling with Conan profiles
+
+## Quick Reference
+
+### Essential Commands
+
+| Task | Command | Notes |
+|------|---------|-------|
+| Install dependencies | `conan install . --output-folder=build --build=missing` | Conan 2.x |
+| Create package | `conan create .` | Build + test a recipe |
+| Export recipe | `conan export .` | Add to local cache |
+| Search packages | `conan search "zlib/*"` | Query remote |
+| Remove package | `conan remove "zlib/*"` | Clean cache |
+| List packages | `conan list "*"` | Show cached packages |
+| Add remote | `conan remote add myremote https://...` | Register remote |
+| Profile detect | `conan profile detect` | Auto-detect compiler |
+
+### conanfile.txt (Simple)
+
+```ini
+[requires]
+zlib/1.3.1
+fmt/10.2.1
+nlohmann_json/3.11.3
+
+[generators]
+CMakeDeps
+CMakeToolchain
+
+[layout]
+cmake_layout
+```
+
+### conanfile.py (Full Control)
+
+```python
+from conan import ConanFile
+from conan.tools.cmake import CMake, cmake_layout, CMakeDeps, CMakeToolchain
+from conan.tools.files import copy, collect_libs
+import os
+
+class MyPkgConan(ConanFile):
+    name = "mypkg"
+    version = "1.0"
+    license = "MIT"
+    settings = "os", "compiler", "build_type", "arch"
+    exports_sources = "CMakeLists.txt", "src/*", "include/*"
+
+    def requirements(self):
+        self.requires("zlib/1.3.1")
+        self.requires("fmt/10.2.1")
+
+    def layout(self):
+        cmake_layout(self)
+
+    def generate(self):
+        deps = CMakeDeps(self)
+        deps.generate()
+        tc = CMakeToolchain(self)
+        tc.generate()
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def package(self):
+        cmake = CMake(self)
+        cmake.install()
+        copy(self, "*.h", src=self.source_folder, dst=os.path.join(self.package_folder, "include"))
+        collect_libs(self)
+
+    def package_info(self):
+        self.cpp_info.libs = ["mypkg"]
+```
+
+## CMake Integration
+
+```cmake
+cmake_minimum_required(VERSION 3.15)
+project(MyApp LANGUAGES CXX)
+
+find_package(zlib REQUIRED)
+find_package(fmt REQUIRED)
+
+add_executable(myapp main.cpp)
+target_link_libraries(myapp PRIVATE zlib::zlib fmt::fmt)
+```
+
+Build workflow:
+```bash
+conan install . --output-folder=build --build=missing -s build_type=Release
+cd build
+cmake .. -DCMAKE_TOOLCHAIN_FILE=conan_toolchain.cmake -DCMAKE_BUILD_TYPE=Release
+cmake --build .
+```
+
+## Common Patterns
+
+### Debug + Release side by side
+
+```bash
+conan install . -of=build-debug -s build_type=Debug --build=missing
+conan install . -of=build-release -s build_type=Release --build=missing
+```
+
+### Header-only libraries
+
+```python
+def package_info(self):
+    self.cpp_info.header_only()
+```
+
+### Custom settings
+
+```ini
+# conanfile.txt with options
+[requires]
+openssl/3.2.0
+
+[options]
+openssl:shared=True
+```
+
+## Common Gotchas
+
+- Always use `--build=missing` in CI to avoid pre-built binary issues
+- Lock files (`conan.lock`) for reproducible builds
+- Use `conan profile detect` to set up compiler profiles
+- Conan 2.x is incompatible with 1.x recipes — migrate carefully
+- Use `CMakeDeps` + `CMakeToolchain` generators (not the old `cmake` generator)
+- Never hardcode paths in recipes — use `self.dependencies` instead
+- Set `settings.compiler.cppstd` for C++ standard version
+
+## Verification Checklist
+
+- [ ] `conan install` completes without errors
+- [ ] `cmake` finds all dependencies via toolchain
+- [ ] Build succeeds with correct linking
+- [ ] `conan create .` passes package tests
+- [ ] No version conflicts in dependency tree

--- a/packages/autoskills/skills-registry/cpp/SKILL.md
+++ b/packages/autoskills/skills-registry/cpp/SKILL.md
@@ -29,7 +29,7 @@ metadata:
 | C++23 | `g++ -std=c++23 -o out file.cpp` | Cutting edge |
 | Debug | `g++ -g -fsanitize=address,undefined -o out file.cpp` | ASan + UBSan |
 | Optimize | `g++ -O2 -march=native -o out file.cpp` | Release build |
-| Concepts (C++20) | `g++ -std=c++20 -concepts -o out file.cpp` | GCC concepts |
+| Concepts (C++20) | `g++ -std=c++20 -o out file.cpp` | Concepts included |
 
 ### Common Flags
 
@@ -100,8 +100,16 @@ std::mutex mtx;
     // critical section
 }
 
-// Scope guard (C++11 pattern)
-auto guard = gsl::finally([&]() { cleanup(); });
+// Scope guard (C++11 pattern with custom RAII)
+class ScopeGuard {
+    std::function<void()> f_;
+public:
+    explicit ScopeGuard(std::function<void()> f) : f_(std::move(f)) {}
+    ~ScopeGuard() { if (f_) f_(); }
+    void dismiss() { f_ = nullptr; }
+};
+
+auto guard = ScopeGuard([&]() { cleanup(); });
 ```
 
 ## STL Quick Reference
@@ -163,16 +171,42 @@ counter.fetch_add(1, std::memory_order_relaxed);
 
 // Thread pool pattern
 class ThreadPool {
-    std::vector<std::thread> workers_;
+    std::vector<std::jthread> workers_;
     std::queue<std::function<void()>> tasks_;
     std::mutex mtx_;
     std::condition_variable cv_;
     bool stop_ = false;
 public:
+    ThreadPool(size_t threads = std::thread::hardware_concurrency()) {
+        for (size_t i = 0; i < threads; ++i) {
+            workers_.emplace_back([this] {
+                while (true) {
+                    std::function<void()> task;
+                    {
+                        std::unique_lock lock(mtx_);
+                        cv_.wait(lock, [this] { return stop_ || !tasks_.empty(); });
+                        if (stop_ && tasks_.empty()) return;
+                        task = std::move(tasks_.front());
+                        tasks_.pop();
+                    }
+                    task();
+                }
+            });
+        }
+    }
+
+    ~ThreadPool() {
+        {
+            std::lock_guard lock(mtx_);
+            stop_ = true;
+        }
+        cv_.notify_all();
+    }
+
     template<typename F>
     void enqueue(F&& f) {
         {
-            std::unique_lock lock(mtx_);
+            std::lock_guard lock(mtx_);
             tasks_.emplace(std::forward<F>(f));
         }
         cv_.notify_one();
@@ -206,7 +240,10 @@ class StaticVector {
     std::array<T, N> data_;
     size_t size_ = 0;
 public:
-    void push_back(const T& val) { data_[size_++] = val; }
+    void push_back(const T& val) {
+        if (size_ >= N) throw std::length_error("StaticVector capacity exceeded");
+        data_[size_++] = val;
+    }
     size_t size() const { return size_; }
 };
 ```

--- a/packages/autoskills/skills-registry/cpp/SKILL.md
+++ b/packages/autoskills/skills-registry/cpp/SKILL.md
@@ -61,7 +61,7 @@ auto ptr = std::make_unique<MyClass>(args);
 auto shared = std::make_shared<MyClass>(args);
 
 // Weak reference (no ownership)
-std::weak_ref<MyClass> weak = shared;
+std::weak_ptr<MyClass> weak = shared;
 if (auto locked = weak.lock()) {
     // Use locked
 }

--- a/packages/autoskills/skills-registry/cpp/SKILL.md
+++ b/packages/autoskills/skills-registry/cpp/SKILL.md
@@ -1,0 +1,252 @@
+---
+name: cpp
+description: "Build modern C++ applications. Use when writing C++17/20/23 code, working with templates, smart pointers, STL containers, concurrency, RAII, or debugging C++ projects. Covers modern idioms, best practices, and common pitfalls."
+metadata:
+  version: "1.0"
+  source: "autoskills"
+---
+
+# C++ Programming
+
+## When to Use
+
+- Writing or reviewing C++ source code (`.cpp` / `.hpp` / `.h` files)
+- Working with modern C++ features (C++17/20/23)
+- Designing class hierarchies, templates, or generic code
+- Memory management with smart pointers
+- Concurrency and multithreading
+- Performance-critical systems programming
+- Building with CMake or other build systems
+
+## Quick Reference
+
+### Compilation
+
+| Task | Command | Notes |
+|------|---------|-------|
+| Compile | `g++ -std=c++17 -o out file.cpp` | C++17 default |
+| C++20 | `g++ -std=c++20 -o out file.cpp` | Latest stable |
+| C++23 | `g++ -std=c++23 -o out file.cpp` | Cutting edge |
+| Debug | `g++ -g -fsanitize=address,undefined -o out file.cpp` | ASan + UBSan |
+| Optimize | `g++ -O2 -march=native -o out file.cpp` | Release build |
+| Concepts (C++20) | `g++ -std=c++20 -concepts -o out file.cpp` | GCC concepts |
+
+### Common Flags
+
+| Flag | Purpose |
+|------|---------|
+| `-std=c++17/20/23` | C++ standard version |
+| `-Wall -Wextra -Wpedantic` | Enable warnings |
+| `-Werror` | Treat warnings as errors |
+| `-fsanitize=address` | AddressSanitizer |
+| `-fsanitize=undefined` | UndefinedBehaviorSanitizer |
+| `-fsanitize=thread` | ThreadSanitizer |
+| `-fno-exceptions` | Disable exceptions (embedded) |
+| `-fno-rtti` | Disable RTTI |
+| `-pthread` | Link POSIX threads |
+| `-fcoroutines` | Enable coroutines (GCC) |
+| `-ftemplate-depth=N` | Increase template depth limit |
+
+## Modern C++ Idioms
+
+### Smart Pointers (RAII)
+
+```cpp
+#include <memory>
+
+// Unique ownership
+auto ptr = std::make_unique<MyClass>(args);
+
+// Shared ownership
+auto shared = std::make_shared<MyClass>(args);
+
+// Weak reference (no ownership)
+std::weak_ref<MyClass> weak = shared;
+if (auto locked = weak.lock()) {
+    // Use locked
+}
+
+// NEVER: raw new/delete in modern C++
+```
+
+### Move Semantics
+
+```cpp
+class Buffer {
+    std::vector<uint8_t> data_;
+public:
+    // Move constructor
+    Buffer(Buffer &&other) noexcept = default;
+    // Move assignment
+    Buffer &operator=(Buffer &&other) noexcept = default;
+
+    // Disable copy
+    Buffer(const Buffer &) = delete;
+    Buffer &operator=(const Buffer &) = delete;
+};
+```
+
+### RAII Wrappers
+
+```cpp
+// File handle
+std::ifstream file("data.txt");
+if (!file) { /* handle error */ }
+
+// Lock guard
+std::mutex mtx;
+{
+    std::lock_guard lock(mtx);  // C++17: CTAD
+    // critical section
+}
+
+// Scope guard (C++11 pattern)
+auto guard = gsl::finally([&]() { cleanup(); });
+```
+
+## STL Quick Reference
+
+### Containers
+
+| Container | Use Case | Header |
+|-----------|----------|--------|
+| `std::vector` | Dynamic array | `<vector>` |
+| `std::string` | String manipulation | `<string>` |
+| `std::unordered_map` | Fast key-value lookup | `<unordered_map>` |
+| `std::map` | Ordered key-value | `<map>` |
+| `std::set` | Unique sorted elements | `<set>` |
+| `std::unordered_set` | Unique fast lookup | `<unordered_set>` |
+| `std::deque` | Double-ended queue | `<deque>` |
+| `std::list` | Doubly-linked list | `<list>` |
+| `std::array` | Fixed-size array | `<array>` |
+
+### Algorithms
+
+```cpp
+#include <algorithm>
+#include <ranges>  // C++20
+
+// C++20 ranges
+auto even = [](int n) { return n % 2 == 0; };
+auto squared = [](int n) { return n * n; };
+
+auto result = numbers
+    | std::views::filter(even)
+    | std::views::transform(squared);
+
+// Traditional
+std::sort(v.begin(), v.end());
+auto it = std::find_if(v.begin(), v.end(), predicate);
+std::transform(v.begin(), v.end(), out.begin(), func);
+std::accumulate(v.begin(), v.end(), init);
+```
+
+## Concurrency
+
+```cpp
+#include <thread>
+#include <mutex>
+#include <future>
+#include <atomic>
+
+// std::thread
+std::thread t([]{ work(); });
+t.join();
+
+// std::async
+auto future = std::async(std::launch::async, []{ return compute(); });
+auto result = future.get();
+
+// std::atomic
+std::atomic<int> counter{0};
+counter.fetch_add(1, std::memory_order_relaxed);
+
+// Thread pool pattern
+class ThreadPool {
+    std::vector<std::thread> workers_;
+    std::queue<std::function<void()>> tasks_;
+    std::mutex mtx_;
+    std::condition_variable cv_;
+    bool stop_ = false;
+public:
+    template<typename F>
+    void enqueue(F&& f) {
+        {
+            std::unique_lock lock(mtx_);
+            tasks_.emplace(std::forward<F>(f));
+        }
+        cv_.notify_one();
+    }
+};
+```
+
+## Templates
+
+```cpp
+// Function template
+template<typename T>
+T clamp(T value, T lo, T hi) {
+    return std::max(lo, std::min(value, hi));
+}
+
+// C++20 Concepts
+template<typename T>
+concept Numeric = std::is_arithmetic_v<T>;
+
+template<Numeric T>
+T add(T a, T b) { return a + b; }
+
+// Variable template
+template<typename T>
+constexpr T pi = T(3.14159265358979323846);
+
+// Class template
+template<typename T, size_t N>
+class StaticVector {
+    std::array<T, N> data_;
+    size_t size_ = 0;
+public:
+    void push_back(const T& val) { data_[size_++] = val; }
+    size_t size() const { return size_; }
+};
+```
+
+## Common Gotchas
+
+- **Slicing**: Pass polymorphic objects by pointer/reference, not by value
+- **Dangling references**: Be careful with `std::string_view` and `std::span`
+- **Integer overflow**: Use checked arithmetic for untrusted input
+- **Use-after-move**: Don't access objects after `std::move()`
+- **Thread safety**: Shared mutable state needs synchronization
+- **One Definition Rule**: Don't define the same function in multiple translation units
+- **Header-only libraries**: Watch compile times with heavy template usage
+- **Exception safety**: Use RAII, prefer `noexcept` on move operations
+- **`auto` pitfalls**: `auto` deduces value types, dropping references — use `auto&` or `decltype(auto)`
+- **Virtual destructors**: Always make base class destructors virtual if using polymorphism
+
+## Debugging
+
+```bash
+# Compile with debug symbols
+g++ -g -O0 -fsanitize=address,undefined -o program program.cpp
+
+# GDB for C++
+gdb ./program
+(gdb) catch throw          # Break on exception
+(gdb) print obj            # Print object
+(gdb) call obj.method()    # Call method
+(gdb) info vtable obj      # Virtual table
+
+# AddressSanitizer output
+# ==12345==ERROR: AddressSanitizer: stack-buffer-overflow
+```
+
+## Verification Checklist
+
+- [ ] Compiled with `-Wall -Wextra -Wpedantic` and no warnings
+- [ ] Smart pointers used instead of raw `new`/`delete`
+- [ ] RAII for resource management
+- [ ] No undefined behavior (UBSan clean)
+- [ ] No memory errors (ASan clean)
+- [ ] Thread safety verified (TSan clean if multithreaded)
+- [ ] Rule of Five/Zero followed for custom types

--- a/packages/autoskills/skills-registry/doxygen/SKILL.md
+++ b/packages/autoskills/skills-registry/doxygen/SKILL.md
@@ -207,7 +207,7 @@ configure_file(${DOXYGEN_IN} ${DOXYGEN_OUT} @ONLY)
 
 add_custom_target(docs
     COMMAND ${DOXYGEN_EXECUTABLE} ${DOXYGEN_OUT}
-    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
     COMMENT "Generating API documentation with Doxygen"
     VERBATIM)
 ```

--- a/packages/autoskills/skills-registry/doxygen/SKILL.md
+++ b/packages/autoskills/skills-registry/doxygen/SKILL.md
@@ -1,0 +1,241 @@
+---
+name: doxygen
+description: "Generate documentation for C/C++ projects with Doxygen. Use when writing Doxyfile configs, documenting code with Doxygen comments, generating HTML/PDF docs, or creating class/library references."
+metadata:
+  version: "1.0"
+  source: "autoskills"
+---
+
+# Doxygen Documentation
+
+## When to Use
+
+- Generating API documentation from C/C++ source code
+- Writing Doxygen-compatible comments and documentation blocks
+- Configuring `Doxyfile` for custom output
+- Creating HTML, PDF, or LaTeX documentation
+- Documenting class hierarchies, modules, and file structures
+- Integrating documentation generation into build systems
+
+## Quick Reference
+
+### Essential Commands
+
+| Task | Command | Notes |
+|------|---------|-------|
+| Generate config | `doxygen -g` | Creates Doxyfile |
+| Generate docs | `doxygen Doxyfile` | Build documentation |
+| Generate + open | `doxygen && open docs/html/index.html` | macOS |
+| Minimal config | `doxygen -s -g` | Stripped-down config |
+
+## Code Documentation Syntax
+
+### File Header
+
+```cpp
+/**
+ * @file mylib.h
+ * @brief Library for managing widgets.
+ * @author John Doe
+ * @date 2026-01-15
+ * @version 2.1.0
+ *
+ * This library provides widget management capabilities
+ * including creation, deletion, and transformation.
+ */
+```
+
+### Function Documentation
+
+```cpp
+/**
+ * @brief Computes the distance between two points.
+ *
+ * @param x1 X coordinate of first point
+ * @param y1 Y coordinate of first point
+ * @param x2 X coordinate of second point
+ * @param y2 Y coordinate of second point
+ * @return Euclidean distance as a double
+ *
+ * @pre Both points must be in the same coordinate system
+ * @post No side effects
+ *
+ * @note Uses double precision for accuracy
+ * @see Point, Vector
+ *
+ * @code
+ * double d = distance(0, 0, 3, 4); // returns 5.0
+ * @endcode
+ */
+double distance(double x1, double y1, double x2, double y2);
+```
+
+### Class Documentation
+
+```cpp
+/**
+ * @class Widget
+ * @brief A graphical user interface element.
+ *
+ * Widget is the base class for all UI elements.
+ * It manages positioning, rendering, and event handling.
+ *
+ * @par Inheritance
+ * Widget is inherited by Button, Label, and TextField.
+ *
+ * @see Button, Label, TextField
+ */
+class Widget {
+public:
+    /**
+     * @brief Constructs a Widget at the given position.
+     *
+     * @param x Horizontal position
+     * @param y Vertical position
+     * @param parent Parent widget (nullable)
+     */
+    Widget(int x, int y, Widget* parent = nullptr);
+
+    /** @brief Virtual destructor for polymorphic deletion. */
+    virtual ~Widget() = default;
+
+    /**
+     * @brief Renders the widget.
+     *
+     * @param ctx Rendering context
+     * @return true if rendering succeeded
+     */
+    virtual bool render(RenderContext& ctx) = 0;
+
+    /**
+     * @brief Widget position.
+     *
+     * @{
+     */
+    int x() const { return x_; }
+    int y() const { return y_; }
+    /** @} */
+};
+```
+
+### Enum Documentation
+
+```cpp
+/**
+ * @enum Alignment
+ * @brief Text alignment options.
+ */
+enum class Alignment {
+    Left,   ///< Align text to the left
+    Center, ///< Center-align text
+    Right,  ///< Align text to the right
+    Justify ///< Justify text (full width)
+};
+```
+
+### Grouping
+
+```cpp
+/**
+ * @defgroup networking Network Communication
+ * @brief HTTP, TCP, and WebSocket utilities.
+ *
+ * @{
+ */
+
+/** @brief HTTP client for REST API calls. */
+class HttpClient { /* ... */ };
+
+/** @brief WebSocket connection handler. */
+class WebSocket { /* ... */ };
+
+/** @} */ // end of networking group
+```
+
+## Doxyfile Configuration
+
+```ini
+# Project
+PROJECT_NAME           = "My Project"
+PROJECT_NUMBER         = "2.1.0"
+PROJECT_BRIEF          = "Widget management library"
+OUTPUT_DIRECTORY       = docs
+
+# Input
+INPUT                  = src include
+FILE_PATTERNS          = *.cpp *.h *.hpp *.c
+RECURSIVE              = YES
+EXCLUDE_PATTERNS       = */test/* */build/*
+
+# Output formats
+GENERATE_HTML          = YES
+GENERATE_LATEX         = NO
+GENERATE_TREEVIEW      = YES
+
+# Extraction
+EXTRACT_ALL            = YES
+EXTRACT_PRIVATE        = NO
+EXTRACT_STATIC         = YES
+
+# Diagrams
+HAVE_DOT               = YES
+DOT_NUM_THREADS        = 4
+CLASS_DIAGRAMS         = YES
+CALL_GRAPH             = YES
+CALLER_GRAPH           = YES
+
+# Warnings
+QUIET                  = YES
+WARN_IF_UNDOCUMENTED   = YES
+WARN_NO_PARAMDOC       = YES
+
+# Optimization
+JAVADOC_AUTOBRIEF      = YES
+BUILTIN_STL_SUPPORT    = YES
+MARKDOWN_SUPPORT       = YES
+```
+
+## CMake Integration
+
+```cmake
+find_package(Doxygen REQUIRED)
+
+set(DOXYGEN_IN ${CMAKE_CURRENT_SOURCE_DIR}/Doxyfile.in)
+set(DOXYGEN_OUT ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile)
+
+configure_file(${DOXYGEN_IN} ${DOXYGEN_OUT} @ONLY)
+
+add_custom_target(docs
+    COMMAND ${DOXYGEN_EXECUTABLE} ${DOXYGEN_OUT}
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+    COMMENT "Generating API documentation with Doxygen"
+    VERBATIM)
+```
+
+## Best Practices
+
+- Use `@brief` for one-line summaries (or rely on `JAVADOC_AUTOBRIEF`)
+- Document all public APIs — use `WARN_NO_PARAMDOC = YES`
+- Use `@param`, `@return`, `@note`, `@see` consistently
+- Group related classes/modules with `@defgroup`
+- Use `@{` and `@}` to mark group members
+- Keep documentation close to code (not in separate files)
+- Use `/**` for documentation, `///` for member docs
+- Check for missing docs: `doxygen Doxyfile 2>&1 | grep "is not documented"`
+
+## Common Gotchas
+
+- `EXTRACT_ALL = YES` documents everything — use `NO` for API-only docs
+- `INPUT` must include all source directories — missing dirs = empty docs
+- `HAVE_DOT = YES` requires Graphviz installed
+- LaTeX output requires a LaTeX distribution (pdflatex)
+- Use `GENERATE_TREEVIEW = YES` for better navigation
+- `WARN_IF_UNDOCUMENTED = YES` helps enforce documentation coverage
+
+## Verification Checklist
+
+- [ ] `doxygen Doxyfile` generates without errors
+- [ ] HTML opens correctly in browser
+- [ ] All public classes/functions are documented
+- [ ] Diagrams render correctly (if HAVE_DOT enabled)
+- [ ] No "not documented" warnings (with WARN_NO_PARAMDOC)

--- a/packages/autoskills/skills-registry/googletest/SKILL.md
+++ b/packages/autoskills/skills-registry/googletest/SKILL.md
@@ -1,0 +1,232 @@
+---
+name: googletest
+description: "Write and run C++ unit tests with Google Test and Google Mock. Use when creating test files, writing assertions, mocking classes, parameterized tests, or integrating GTest with CMake. Covers GTest 1.14+."
+metadata:
+  version: "1.0"
+  source: "autoskills"
+---
+
+# Google Test (GTest + GMock)
+
+## When to Use
+
+- Writing unit tests for C/C++ code
+- Creating test fixtures for shared setup/teardown
+- Mocking classes and functions with Google Mock
+- Parameterized testing
+- Setting up test suites with CMake integration
+- Writing death tests for crash/assertion handling
+
+## Quick Reference
+
+### Essential Patterns
+
+| Pattern | Macro/Class | Notes |
+|---------|-------------|-------|
+| Test | `TEST(Suite, Name)` | Simple test case |
+| Test fixture | `TEST_F(Fixture, Name)` | Shared state |
+| Assertion | `EXPECT_EQ`, `ASSERT_TRUE` | Non-fatal / fatal |
+| Mock | `MOCK_METHOD` | Define mock methods |
+| Death test | `EXPECT_DEATH` | Test crashes/assertions |
+| Parameterized | `TEST_P` | Data-driven tests |
+| Type parameterized | `TYPED_TEST` | Generic tests |
+
+## Writing Tests
+
+### Basic Test
+
+```cpp
+#include <gtest/gtest.h>
+#include "mylib.h"
+
+TEST(MathTest, Addition) {
+    EXPECT_EQ(add(2, 3), 5);
+}
+
+TEST(MathTest, DivisionByZero) {
+    EXPECT_THROW(divide(1, 0), std::invalid_argument);
+}
+```
+
+### Test Fixtures
+
+```cpp
+class DatabaseTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        db_.connect(":memory:");
+        db_.execute("CREATE TABLE users (id INT, name TEXT)");
+    }
+
+    void TearDown() override {
+        db_.disconnect();
+    }
+
+    Database db_;
+};
+
+TEST_F(DatabaseTest, InsertAndQuery) {
+    db_.execute("INSERT INTO users VALUES (1, 'Alice')");
+    auto result = db_.query("SELECT name FROM users WHERE id=1");
+    EXPECT_EQ(result.size(), 1u);
+    EXPECT_EQ(result[0]["name"], "Alice");
+}
+```
+
+### Google Mock
+
+```cpp
+class Logger {
+public:
+    virtual ~Logger() = default;
+    virtual void log(const std::string& msg) = 0;
+    virtual void flush() = 0;
+};
+
+class MockLogger : public Logger {
+public:
+    MOCK_METHOD(void, log, (const std::string& msg), (override));
+    MOCK_METHOD(void, flush, (), (override));
+};
+
+TEST(ServiceTest, LogsOnFailure) {
+    MockLogger logger;
+    Service service(&logger);
+
+    EXPECT_CALL(logger, log(testing::HasSubstr("error")))
+        .Times(1);
+    EXPECT_CALL(logger, flush()).Times(1);
+
+    service.processInvalidInput();
+}
+```
+
+### Argument Matchers
+
+```cpp
+using testing::_;
+using testing::Eq;
+using testing::HasSubstr;
+using testing::Return;
+using testing::NotNull;
+using testing::AllOf;
+using testing::Ge;
+
+EXPECT_CALL(mock, func(HasSubstr("hello")));
+EXPECT_CALL(mock, func(AllOf(Ge(0), Le(100))));
+EXPECT_CALL(mock, func(_)).WillRepeatedly(Return(true));
+```
+
+### Parameterized Tests
+
+```cpp
+class PrimeTest : public ::testing::TestWithParam<int> {};
+
+TEST_P(PrimeTest, IsPrime) {
+    EXPECT_TRUE(isPrime(GetParam()));
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    Primes,
+    PrimeTest,
+    ::testing::Values(2, 3, 5, 7, 11, 13, 17, 19, 23, 29));
+```
+
+### Type Parameterized Tests
+
+```cpp
+template<typename T>
+class NumericTest : public ::testing::Test {};
+
+TYPED_TEST(NumericTest, ZeroIsZero) {
+    using T = TypeParam;
+    T zero = 0;
+    EXPECT_EQ(zero + zero, zero);
+}
+
+TYPED_TEST_SUITE(NumericTest, ::testing::Types<int, float, double>);
+```
+
+### Death Tests
+
+```cpp
+TEST(AbortTest, NullPointerCausesAbort) {
+    EXPECT_DEATH({
+        int* p = nullptr;
+        *p = 42;
+    }, ".*");
+}
+```
+
+## CMake Integration
+
+```cmake
+include(FetchContent)
+FetchContent_Declare(
+    googletest
+    GIT_REPOSITORY https://github.com/google/googletest.git
+    GIT_TAG v1.14.0
+)
+FetchContent_MakeAvailable(googletest)
+
+enable_testing()
+find_package(GTest REQUIRED)
+
+add_executable(tests test_main.cpp test_mylib.cpp)
+target_link_libraries(tests PRIVATE GTest::gtest_main mylib)
+
+include(GoogleTest)
+gtest_discover_tests(tests)
+```
+
+## Command Line
+
+```bash
+# Run all tests
+./tests
+
+# Run specific test
+./tests --gtest_filter=MathTest.Addition
+
+# Run all tests matching pattern
+./tests --gtest_filter=MathTest.*
+
+# List available tests
+./tests --gtest_list_tests
+
+# Repeat N times
+./tests --gtest_repeat=100
+
+# Print non-fatal failures
+./tests --gtest_print_time=1
+
+# Shuffle tests
+./tests --gtest_shuffle
+```
+
+## Best Practices
+
+- Use `EXPECT_*` (non-fatal) over `ASSERT_*` (fatal) when possible
+- One logical assertion per test — but multiple `EXPECT_*` is fine
+- Use descriptive test names: `TEST_F(ServiceTest, ReturnsErrorWhenDatabaseUnavailable)`
+- Keep `SetUp`/`TearDown` simple — avoid complex logic in fixtures
+- Use `NiceMock<T>` to suppress unexpected call warnings
+- Use `TEST_P` for data-driven tests with many input combinations
+- Use `testing::StrictMock<T>` to fail on any unexpected call
+
+## Common Gotchas
+
+- `ASSERT_*` aborts the current function on failure — use sparingly
+- Mock expectations are checked at destruction time (end of test scope)
+- Use `WillOnce` for exact call counts, `WillRepeatedly` for default behavior
+- `EXPECT_CALL` order matters — later expectations take precedence
+- Link against `GTest::gtest_main` to skip writing your own `main()`
+- `gtest_discover_tests` requires CMake 3.10+ and CTest
+
+## Verification Checklist
+
+- [ ] All tests pass with `meson test` or `ctest`
+- [ ] No memory leaks (ASan clean)
+- [ ] Mock expectations are verified (no uninteresting mock warnings)
+- [ ] Death tests cover critical invariants
+- [ ] Test names are descriptive

--- a/packages/autoskills/skills-registry/googletest/SKILL.md
+++ b/packages/autoskills/skills-registry/googletest/SKILL.md
@@ -111,6 +111,7 @@ using testing::Return;
 using testing::NotNull;
 using testing::AllOf;
 using testing::Ge;
+using testing::Le;
 
 EXPECT_CALL(mock, func(HasSubstr("hello")));
 EXPECT_CALL(mock, func(AllOf(Ge(0), Le(100))));
@@ -150,11 +151,8 @@ TYPED_TEST_SUITE(NumericTest, ::testing::Types<int, float, double>);
 ### Death Tests
 
 ```cpp
-TEST(AbortTest, NullPointerCausesAbort) {
-    EXPECT_DEATH({
-        int* p = nullptr;
-        *p = 42;
-    }, ".*");
+TEST(AbortTest, AssertionCausesAbort) {
+    EXPECT_DEATH(std::abort(), ".*");
 }
 ```
 
@@ -170,7 +168,6 @@ FetchContent_Declare(
 FetchContent_MakeAvailable(googletest)
 
 enable_testing()
-find_package(GTest REQUIRED)
 
 add_executable(tests test_main.cpp test_mylib.cpp)
 target_link_libraries(tests PRIVATE GTest::gtest_main mylib)

--- a/packages/autoskills/skills-registry/googletest/SKILL.md
+++ b/packages/autoskills/skills-registry/googletest/SKILL.md
@@ -225,7 +225,7 @@ gtest_discover_tests(tests)
 
 ## Verification Checklist
 
-- [ ] All tests pass with `meson test` or `ctest`
+- [ ] All tests pass with `ctest` or `./tests`
 - [ ] No memory leaks (ASan clean)
 - [ ] Mock expectations are verified (no uninteresting mock warnings)
 - [ ] Death tests cover critical invariants

--- a/packages/autoskills/skills-registry/index.json
+++ b/packages/autoskills/skills-registry/index.json
@@ -13018,6 +13018,186 @@
         "summary": "Official ElysiaJS skill with standard documentation",
         "checkedAt": "2026-05-13T21:40:00.000Z"
       }
+    },
+    "c": {
+      "source": "autoskills",
+      "skillPath": "autoskills/c",
+      "commitSha": "local",
+      "files": [
+        "SKILL.md"
+      ],
+      "sha256": {
+        "SKILL.md": "ec92be177e3a3b30edf86234fc56bf57390d48c6533fd908296ed4b94e48867e"
+      },
+      "bundleHash": "2d46da09b13dcd253a8f911c244576122fb7d027d61b0a9a43027eaf58fc306b",
+      "review": {
+        "status": "approved",
+        "flags": [],
+        "summary": "C programming skill covering compilation, memory management, POSIX, and debugging",
+        "model": "manual",
+        "promptVersion": "1.0.0",
+        "reviewedAt": "2026-07-12T15:41:00.000Z"
+      }
+    },
+    "cpp": {
+      "source": "autoskills",
+      "skillPath": "autoskills/cpp",
+      "commitSha": "local",
+      "files": [
+        "SKILL.md"
+      ],
+      "sha256": {
+        "SKILL.md": "1fb855c1583bcba3e923f853a4145f55a5ba2c8f6c0ca958e7406cd6ba0eb0e4"
+      },
+      "bundleHash": "67eaee4d89350fcb78316e0e11730f2356c22cb2f1e88340939577f596f6c1c3",
+      "review": {
+        "status": "approved",
+        "flags": [],
+        "summary": "Modern C++ skill covering C++17/20/23, STL, smart pointers, concurrency, and templates",
+        "model": "manual",
+        "promptVersion": "1.0.0",
+        "reviewedAt": "2026-07-12T15:41:00.000Z"
+      }
+    },
+    "cmake": {
+      "source": "autoskills",
+      "skillPath": "autoskills/cmake",
+      "commitSha": "local",
+      "files": [
+        "SKILL.md"
+      ],
+      "sha256": {
+        "SKILL.md": "b626d6887833fb1fa97ff1bb8d4e5deb35f64d1891acafc6d0c99db9171ff017"
+      },
+      "bundleHash": "9ecd47b93f9faff35aeb54510fe7e72d7cf261a2875306016620220f4a78e131",
+      "review": {
+        "status": "approved",
+        "flags": [],
+        "summary": "CMake build system skill covering CMakeLists.txt, dependencies, testing, and packaging",
+        "model": "manual",
+        "promptVersion": "1.0.0",
+        "reviewedAt": "2026-07-12T15:41:00.000Z"
+      }
+    },
+    "qt": {
+      "source": "autoskills",
+      "skillPath": "autoskills/qt",
+      "commitSha": "local",
+      "files": [
+        "SKILL.md"
+      ],
+      "sha256": {
+        "SKILL.md": "d5790fd08b917e23fa39949cdac80083d54a1b0fc3c531f95a9fa171af0374d7"
+      },
+      "bundleHash": "42f2ad4b6f69b9993b6072d65f601330ee89733bd625ef3900282f8a1ccc74ef",
+      "review": {
+        "status": "approved",
+        "flags": [],
+        "summary": "Qt 6 framework skill covering Widgets, QML, signals/slots, model/view, threading, and CMake integration",
+        "model": "manual",
+        "promptVersion": "1.0.0",
+        "reviewedAt": "2026-07-12T15:41:00.000Z"
+      }
+    },
+    "conan": {
+      "source": "autoskills",
+      "skillPath": "autoskills/conan",
+      "commitSha": "local",
+      "files": [
+        "SKILL.md"
+      ],
+      "sha256": {
+        "SKILL.md": "8f60c483cfc4edbc98dc6658f50afe846957d4841d768c4c026abc51d16885ac"
+      },
+      "bundleHash": "334af87f1c5022ba0f727ba4b20c0d3a7b6466d5caa9eabca7d5162e25637ad7",
+      "review": {
+        "status": "approved",
+        "flags": [],
+        "summary": "Conan C++ package manager skill covering conanfile recipes, CMake integration, and dependency management",
+        "model": "manual",
+        "promptVersion": "1.0.0",
+        "reviewedAt": "2026-07-12T15:42:00.000Z"
+      }
+    },
+    "vcpkg": {
+      "source": "autoskills",
+      "skillPath": "autoskills/vcpkg",
+      "commitSha": "local",
+      "files": [
+        "SKILL.md"
+      ],
+      "sha256": {
+        "SKILL.md": "7afc2851a4f63161514d364f6f5ebea46a1826ef9fb975ade47e6c4de970f2fa"
+      },
+      "bundleHash": "956e6c2f2ec749b29dab5436a25a9504ff03e43823c34e541d7c05e813941ebe",
+      "review": {
+        "status": "approved",
+        "flags": [],
+        "summary": "vcpkg C++ package manager skill covering manifest mode, triplets, binary caching, and CMake integration",
+        "model": "manual",
+        "promptVersion": "1.0.0",
+        "reviewedAt": "2026-07-12T15:42:00.000Z"
+      }
+    },
+    "meson": {
+      "source": "autoskills",
+      "skillPath": "autoskills/meson",
+      "commitSha": "local",
+      "files": [
+        "SKILL.md"
+      ],
+      "sha256": {
+        "SKILL.md": "b2cbfcf8ec8a72097a3a7a710951769721ee6a55a86768049c42741f222ed3ba"
+      },
+      "bundleHash": "012ed83cd5ad9a5c9a8f80d6487b416eb8dba781b790e881a4d7f6c3b68c03fb",
+      "review": {
+        "status": "approved",
+        "flags": [],
+        "summary": "Meson build system skill covering meson.build, dependencies, cross-compilation, and Ninja backend",
+        "model": "manual",
+        "promptVersion": "1.0.0",
+        "reviewedAt": "2026-07-12T15:42:00.000Z"
+      }
+    },
+    "googletest": {
+      "source": "autoskills",
+      "skillPath": "autoskills/googletest",
+      "commitSha": "local",
+      "files": [
+        "SKILL.md"
+      ],
+      "sha256": {
+        "SKILL.md": "503fe7f4fa8bcde6b617cdec84f33a02be39787177a5230c1968a5f0bf47df10"
+      },
+      "bundleHash": "5bbf5fdfd0e3307c2eed892ebc90609c20865f5215cabcb7a8cc8138a27648bf",
+      "review": {
+        "status": "approved",
+        "flags": [],
+        "summary": "Google Test skill covering unit testing, mocking, fixtures, parameterized tests, and CMake integration",
+        "model": "manual",
+        "promptVersion": "1.0.0",
+        "reviewedAt": "2026-07-12T15:42:00.000Z"
+      }
+    },
+    "doxygen": {
+      "source": "autoskills",
+      "skillPath": "autoskills/doxygen",
+      "commitSha": "local",
+      "files": [
+        "SKILL.md"
+      ],
+      "sha256": {
+        "SKILL.md": "342857c064c479888594e9bacc19f351cd53701a67821de532b30f5c72f5b753"
+      },
+      "bundleHash": "eea7fd1df64c84b0345e55ca72020ebba5bc8806ed6499028693c67eccce7157",
+      "review": {
+        "status": "approved",
+        "flags": [],
+        "summary": "Doxygen documentation skill covering Doxyfile config, code comments, and HTML/PDF generation",
+        "model": "manual",
+        "promptVersion": "1.0.0",
+        "reviewedAt": "2026-07-12T15:42:00.000Z"
+      }
     }
   }
 }

--- a/packages/autoskills/skills-registry/index.json
+++ b/packages/autoskills/skills-registry/index.json
@@ -13022,7 +13022,7 @@
     "c": {
       "source": "autoskills",
       "skillPath": "autoskills/c",
-      "commitSha": "local",
+      "commitSha": "7ebf5ce92e8ed0521949111d8ff91ec5047d7c83",
       "files": [
         "SKILL.md"
       ],
@@ -13042,7 +13042,7 @@
     "cpp": {
       "source": "autoskills",
       "skillPath": "autoskills/cpp",
-      "commitSha": "local",
+      "commitSha": "7ebf5ce92e8ed0521949111d8ff91ec5047d7c83",
       "files": [
         "SKILL.md"
       ],
@@ -13062,7 +13062,7 @@
     "cmake": {
       "source": "autoskills",
       "skillPath": "autoskills/cmake",
-      "commitSha": "local",
+      "commitSha": "7ebf5ce92e8ed0521949111d8ff91ec5047d7c83",
       "files": [
         "SKILL.md"
       ],
@@ -13082,7 +13082,7 @@
     "qt": {
       "source": "autoskills",
       "skillPath": "autoskills/qt",
-      "commitSha": "local",
+      "commitSha": "7ebf5ce92e8ed0521949111d8ff91ec5047d7c83",
       "files": [
         "SKILL.md"
       ],
@@ -13102,7 +13102,7 @@
     "conan": {
       "source": "autoskills",
       "skillPath": "autoskills/conan",
-      "commitSha": "local",
+      "commitSha": "7ebf5ce92e8ed0521949111d8ff91ec5047d7c83",
       "files": [
         "SKILL.md"
       ],
@@ -13122,7 +13122,7 @@
     "vcpkg": {
       "source": "autoskills",
       "skillPath": "autoskills/vcpkg",
-      "commitSha": "local",
+      "commitSha": "7ebf5ce92e8ed0521949111d8ff91ec5047d7c83",
       "files": [
         "SKILL.md"
       ],
@@ -13142,7 +13142,7 @@
     "meson": {
       "source": "autoskills",
       "skillPath": "autoskills/meson",
-      "commitSha": "local",
+      "commitSha": "7ebf5ce92e8ed0521949111d8ff91ec5047d7c83",
       "files": [
         "SKILL.md"
       ],
@@ -13162,7 +13162,7 @@
     "googletest": {
       "source": "autoskills",
       "skillPath": "autoskills/googletest",
-      "commitSha": "local",
+      "commitSha": "7ebf5ce92e8ed0521949111d8ff91ec5047d7c83",
       "files": [
         "SKILL.md"
       ],
@@ -13182,7 +13182,7 @@
     "doxygen": {
       "source": "autoskills",
       "skillPath": "autoskills/doxygen",
-      "commitSha": "local",
+      "commitSha": "7ebf5ce92e8ed0521949111d8ff91ec5047d7c83",
       "files": [
         "SKILL.md"
       ],

--- a/packages/autoskills/skills-registry/meson/SKILL.md
+++ b/packages/autoskills/skills-registry/meson/SKILL.md
@@ -168,7 +168,7 @@ meson configure builddir -Db_lto=true
 - Build directory must not exist before `meson setup`
 - Use `--wipe` to reconfigure (deletes build dir)
 - Dependencies default to `required: true` — set `required: false` for optional
-- `meson.compile()` is preferred over raw `ninja` invocation
+- `meson compile -C builddir` is preferred over raw `ninja` invocation
 - Subprojects are in `subprojects/` directory — use `meson subprojects update`
 - WrapDB wraps are auto-downloaded on first build
 - Use `import('pkgconfig').generate()` to create `.pc` files

--- a/packages/autoskills/skills-registry/meson/SKILL.md
+++ b/packages/autoskills/skills-registry/meson/SKILL.md
@@ -1,0 +1,184 @@
+---
+name: meson
+description: "Build C/C++ projects with the Meson build system. Use when writing meson.build files, configuring dependencies with pkg-config or wraps, cross-compiling, or working with Ninja backend. Covers Meson 1.x."
+metadata:
+  version: "1.0"
+  source: "autoskills"
+---
+
+# Meson Build System
+
+## When to Use
+
+- Writing or maintaining `meson.build` files
+- Managing dependencies via pkg-config or WrapDB
+- Cross-compiling with cross files
+- Setting up test suites
+- Building with Ninja backend (default)
+- Alternative to CMake for new C/C++ projects
+
+## Quick Reference
+
+### Essential Commands
+
+| Task | Command | Notes |
+|------|---------|-------|
+| Configure | `meson setup builddir` | Create build directory |
+| Build | `meson compile -C builddir` | Compile the project |
+| Test | `meson test -C builddir` | Run test suite |
+| Install | `meson install -C builddir` | Install to prefix |
+| Clean | `meson setup builddir --wipe` | Reconfigure from scratch |
+| Reconfigure | `meson configure builddir` | Change options |
+| Introspect | `meson introspect builddir` | Query build info |
+
+## meson.build Patterns
+
+### Minimal Project
+
+```meson
+project('myproject', 'cpp',
+  version: '1.0.0',
+  default_options: ['cpp_std=c++17', 'warning_level=2'])
+
+executable('myapp', 'main.cpp',
+  install: true)
+```
+
+### Library + Executable
+
+```meson
+project('myproject', 'cpp',
+  version: '1.0.0',
+  default_options: ['cpp_std=c++17'])
+
+# Shared library
+mylib = shared_library('mylib',
+  sources: ['src/mylib.cpp'],
+  include_directories: include_directories('include'),
+  install: true)
+
+# Declare dependency for consumers
+mylib_dep = declare_dependency(
+  include_directories: include_directories('include'),
+  link_with: mylib)
+
+# Executable
+executable('myapp',
+  sources: ['main.cpp'],
+  dependencies: [mylib_dep],
+  install: true)
+```
+
+### Dependencies
+
+```meson
+# pkg-config (auto-detected)
+fmt_dep = dependency('fmt', required: true)
+nlohmann_json_dep = dependency('nlohmann_json', required: true)
+
+# WrapDB
+fmt_dep = dependency('fmt', fallback: ['fmt', 'fmt_dep'])
+
+# Subproject
+subdir('vendor/mylib')
+mylib_dep = mylib.get_variable('mylib_dep')
+
+# Build options
+option('use_ssl', type: 'boolean', value: true, description: 'Enable SSL support')
+```
+
+### Testing
+
+```meson
+test('basic_test', executable('test_basic',
+  sources: ['tests/test_basic.cpp'],
+  dependencies: [mylib_dep]))
+
+test('advanced_test', executable('test_advanced',
+  sources: ['tests/test_advanced.cpp'],
+  dependencies: [mylib_dep]),
+  timeout: 60)
+```
+
+### Custom Targets
+
+```meson
+# Code generation
+custom_target('generated',
+  input: 'schema.json',
+  output: 'generated.h',
+  command: [find_program('generate'), '@INPUT@', '@OUTPUT@'],
+  install: true,
+  install_dir: 'include')
+
+# Custom script
+run_target('docs',
+  command: [find_program('doxygen'), 'Doxyfile'])
+```
+
+## Cross Compilation
+
+```ini
+# cross.ini
+[binaries]
+c = 'arm-linux-gnueabihf-gcc'
+cpp = 'arm-linux-gnueabihf-g++'
+ar = 'arm-linux-gnueabihf-ar'
+strip = 'arm-linux-gnueabihf-strip'
+
+[host_machine]
+system = 'linux'
+cpu_family = 'arm'
+cpu = 'cortex-a7'
+endian = 'little'
+
+[properties]
+needs_exe_wrapper = true
+```
+
+```bash
+meson setup builddir --cross-file cross.ini
+```
+
+## Build Options
+
+```bash
+# List all options
+meson configure builddir
+
+# Set option
+meson configure builddir -Duse_ssl=true
+meson configure builddir -Dbuildtype=debugoptimized
+meson configure builddir -Db_lto=true
+```
+
+## Common Options
+
+| Option | Values | Default |
+|--------|--------|---------|
+| `buildtype` | `debug`, `debugoptimized`, `release`, `minsize` | `debugoptimized` |
+| `cpp_std` | `c++11`, `c++14`, `c++17`, `c++20`, `c++23` | compiler default |
+| `warning_level` | `0`, `1`, `2`, `3` | `1` |
+| `b_lto` | `true`, `false` | `false` |
+| `default_library` | `shared`, `static`, `both` | `shared` |
+| `prefix` | path | `/usr/local` |
+
+## Common Gotchas
+
+- Build directory must not exist before `meson setup`
+- Use `--wipe` to reconfigure (deletes build dir)
+- Dependencies default to `required: true` — set `required: false` for optional
+- `meson.compile()` is preferred over raw `ninja` invocation
+- Subprojects are in `subprojects/` directory — use `meson subprojects update`
+- WrapDB wraps are auto-downloaded on first build
+- Use `import('pkgconfig').generate()` to create `.pc` files
+- Cross-compilation requires a cross file
+
+## Verification Checklist
+
+- [ ] `meson setup builddir` completes without errors
+- [ ] `meson compile -C builddir` builds successfully
+- [ ] `meson test -C builddir` passes all tests
+- [ ] Dependencies found via pkg-config or wraps
+- [ ] Correct `cpp_std` set for project requirements
+- [ ] Install rules configured if needed

--- a/packages/autoskills/skills-registry/qt/SKILL.md
+++ b/packages/autoskills/skills-registry/qt/SKILL.md
@@ -1,0 +1,297 @@
+---
+name: qt
+description: "Build cross-platform C++ and QML applications with Qt. Use when creating GUI apps with Widgets or Qt Quick, working with signals/slots, model/view architecture, networking, database access, multimedia, threading, or building with CMake/qmake. Covers Qt 6.x."
+metadata:
+  version: "1.0"
+  source: "autoskills"
+---
+
+# Qt Framework
+
+## When to Use
+
+- Creating cross-platform GUI applications (Desktop, Mobile, Embedded)
+- Working with signals & slots communication pattern
+- Building UIs with Widgets (classic) or Qt Quick/QML (declarative)
+- Model/View architecture with `QAbstractItemModel`
+- Networking (HTTP, TCP/UDP, WebSocket)
+- Database access with `QSqlDatabase`
+- Multimedia (audio, video, camera)
+- Threading with `QThread` or `QtConcurrent`
+- Building with CMake (preferred) or qmake (legacy)
+- Exposing C++ objects to QML via `Q_PROPERTY` or context properties
+
+## Build System: CMake (Qt 6)
+
+Qt 6 recommends CMake. Minimum `CMakeLists.txt`:
+
+```cmake
+cmake_minimum_required(VERSION 3.16)
+project(MyApp VERSION 1.0 LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_AUTOMOC ON)
+
+find_package(Qt6 REQUIRED COMPONENTS Core Widgets)
+
+qt_add_executable(MyApp
+    main.cpp
+    mainwindow.cpp
+    mainwindow.h
+)
+
+target_link_libraries(MyApp PRIVATE Qt6::Core Qt6::Widgets)
+```
+
+Build:
+```bash
+cmake -B build -DCMAKE_PREFIX_PATH=/path/to/qt6
+cmake --build build
+```
+
+For QML-only apps:
+```cmake
+qt_add_executable(MyApp main.cpp)
+qt_add_qml_module(MyApp
+    URI MyApp
+    VERSION 1.0
+    QML_FILES Main.qml
+)
+```
+
+## Signals & Slots
+
+### C++ Declaration
+
+```cpp
+class MyClass : public QObject {
+    Q_OBJECT
+public:
+    explicit MyClass(QObject *parent = nullptr);
+
+signals:
+    void dataReady(const QString &data);
+    void errorOccurred(int code, const QString &msg);
+
+public slots:
+    void processData(const QString &input);
+    void reset();
+};
+
+// Connection
+MyClass source, target;
+QObject::connect(&source, &MyClass::dataReady, &target, &MyClass::processData);
+
+// Lambda
+QObject::connect(&source, &MyClass::errorOccurred,
+    [](int code, const QString &msg) {
+        qWarning() << "Error" << code << ":" << msg;
+    });
+```
+
+### QML Connections
+
+```qml
+import QtQuick
+
+Rectangle {
+    id: root
+    color: "white"
+
+    MouseArea {
+        onClicked: console.log("Clicked at", mouse.x, mouse.y)
+    }
+
+    Connections {
+        target: backend
+        function onDataReady(data) { label.text = data }
+    }
+}
+```
+
+## QML Basics
+
+```qml
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+
+ApplicationWindow {
+    visible: true
+    width: 640
+    height: 480
+    title: qsTr("My App")
+
+    ColumnLayout {
+        anchors.fill: parent
+        anchors.margins: 16
+
+        TextField {
+            id: input
+            placeholderText: qsTr("Enter text...")
+            Layout.fillWidth: true
+        }
+
+        Button {
+            text: qsTr("Submit")
+            enabled: input.text.length > 0
+            onClicked: backend.submit(input.text)
+        }
+
+        ListView {
+            Layout.fillWidth: true
+            Layout.fillHeight: true
+            model: listModel
+            delegate: Label {
+                required property string display
+                text: display
+                padding: 8
+            }
+        }
+    }
+}
+```
+
+## Model/View (C++)
+
+```cpp
+class StringListModel : public QAbstractListModel {
+    Q_OBJECT
+public:
+    enum Roles { NameRole = Qt::UserRole + 1 };
+
+    int rowCount(const QModelIndex &parent = QModelIndex()) const override {
+        return m_data.size();
+    }
+
+    QVariant data(const QModelIndex &index, int role) const override {
+        if (!index.isValid()) return {};
+        if (role == NameRole || role == Qt::DisplayRole)
+            return m_data.at(index.row());
+        return {};
+    }
+
+    QHash<int, QByteArray> roleNames() const override {
+        return { { NameRole, "name" } };
+    }
+
+    void appendString(const QString &str) {
+        beginInsertRows(QModelIndex(), m_data.size(), m_data.size());
+        m_data.append(str);
+        endInsertRows();
+    }
+
+private:
+    QStringList m_data;
+};
+```
+
+## Threading
+
+```cpp
+// Worker object pattern (preferred over subclassing QThread)
+class Worker : public QObject {
+    Q_OBJECT
+public slots:
+    void doWork(const QString &param) {
+        QString result = /* ... */;
+        emit resultReady(result);
+    }
+signals:
+    void resultReady(const QString &result);
+};
+
+// Usage
+QThread *thread = QThread::create([=]() {
+    // Or use QtConcurrent::run
+});
+Worker *worker = new Worker;
+worker->moveToThread(thread);
+connect(thread, &QThread::started, worker, [=]() { worker->doWork("data"); });
+connect(worker, &Worker::resultReady, this, &MainWindow::handleResult);
+connect(worker, &Worker::resultReady, thread, &QThread::quit);
+connect(thread, &QThread::finished, worker, &QObject::deleteLater);
+connect(thread, &QThread::finished, thread, &QObject::deleteLater);
+thread->start();
+```
+
+## Exposing C++ to QML
+
+```cpp
+#include <QGuiApplication>
+#include <QQmlApplicationEngine>
+#include <QQmlContext>
+#include "backend.h"
+
+int main(int argc, char *argv[]) {
+    QGuiApplication app(argc, argv);
+    QQmlApplicationEngine engine;
+
+    Backend backend;
+    engine.rootContext()->setContextProperty("backend", &backend);
+
+    engine.load(QUrl(QStringLiteral("qrc:/Main.qml")));
+    return app.exec();
+}
+```
+
+### Q_PROPERTY
+
+```cpp
+class Person : public QObject {
+    Q_OBJECT
+    Q_PROPERTY(QString name READ name WRITE setName NOTIFY nameChanged)
+public:
+    QString name() const { return m_name; }
+    void setName(const QString &name) {
+        if (m_name != name) {
+            m_name = name;
+            emit nameChanged();
+        }
+    }
+signals:
+    void nameChanged();
+private:
+    QString m_name;
+};
+```
+
+## Best Practices
+
+- Use **CMake** for Qt 6 projects (qmake is legacy)
+- Always use `Q_OBJECT` macro in classes that define signals/slots
+- Use **qmlformat** and **clang-format** for code style
+- Prefer `moveToThread()` pattern over subclassing QThread
+- Use `QPointer` for weak references to QObjects
+- Use `QScopedPointer` for automatic cleanup
+- Set `CMAKE_AUTOMOC ON` to handle MOC automatically
+- Use `qsTr()` in QML for translatable strings
+- Prefer `Connections` type in QML over `connect()` in JS
+- Use `Q_PROPERTY` for exposing C++ data to QML
+- Bundle resources with `qt_add_resources()` or `.qrc` files
+- Use `QSettings` for persistent app configuration
+- Handle `QNetworkReply::errorOccurred` for robust networking
+- Use `QQuickStyle` to set the Qt Quick Controls style
+
+## Debugging & Tools
+
+- **Qt Creator** — IDE with debugger, profiler, visual editor
+- **QML Debugger** — Attach to running QML apps for live editing
+- **Qt Designer** — Visual UI designer for Widgets
+- **`qDebug()`** — Primary debug output stream
+- **`QT_LOGGING_RULES`** — Control debug output categories
+- **Valgrind / LeakSanitizer** — Memory leak detection
+- **Qt Quick Compiler** — Pre-compile QML for performance
+
+## Common Issues & Fixes
+
+| Issue | Solution |
+|-------|----------|
+| `moc` not found | Enable `CMAKE_AUTOMOC ON` |
+| QML module not found | Ensure `qt_add_qml_module` URI matches `import` in QML |
+| Signals not connecting | Verify `Q_OBJECT` macro is in class declaration |
+| `Q_PROPERTY` not working in QML | Ensure getter, setter, and signal all exist |
+| Thread affinity issues | Use `moveToThread()`, never access GUI from worker thread |
+| Resource embedding fails | Check `.qrc` file paths are relative to its location |
+| Deployment missing plugins | Use `windeployqt`, `macdeployqt`, or `linuxdeployqt` |

--- a/packages/autoskills/skills-registry/qt/SKILL.md
+++ b/packages/autoskills/skills-registry/qt/SKILL.md
@@ -98,9 +98,20 @@ import QtQuick
 Rectangle {
     id: root
     color: "white"
+    width: 300; height: 200
+
+    Text {
+        id: label
+        text: "Waiting..."
+    }
 
     MouseArea {
+        anchors.fill: parent
         onClicked: console.log("Clicked at", mouse.x, mouse.y)
+    }
+
+    ListModel {
+        id: listModel
     }
 
     Connections {
@@ -203,15 +214,13 @@ signals:
 };
 
 // Usage
-QThread *thread = QThread::create([=]() {
-    // Or use QtConcurrent::run
-});
+QThread *thread = new QThread;
 Worker *worker = new Worker;
 worker->moveToThread(thread);
 connect(thread, &QThread::started, worker, [=]() { worker->doWork("data"); });
+connect(thread, &QThread::finished, worker, &QObject::deleteLater);
 connect(worker, &Worker::resultReady, this, &MainWindow::handleResult);
 connect(worker, &Worker::resultReady, thread, &QThread::quit);
-connect(thread, &QThread::finished, worker, &QObject::deleteLater);
 connect(thread, &QThread::finished, thread, &QObject::deleteLater);
 thread->start();
 ```

--- a/packages/autoskills/skills-registry/vcpkg/SKILL.md
+++ b/packages/autoskills/skills-registry/vcpkg/SKILL.md
@@ -30,7 +30,7 @@ metadata:
 | Update packages | `vcpkg update` | Show outdated packages |
 | Export package | `vcpkg export <name>` | Create relocatable package |
 | List installed | `vcpkg list` | Show installed packages |
-| Detect triplet | `vcpkg detect` | Auto-detect target triplet |
+| Help triplet | `vcpkg help triplet` | List available triplets |
 
 ### vcpkg.json (Manifest)
 
@@ -103,14 +103,15 @@ cmake --build build
 
 ```bash
 # Custom triplet for static linking on Linux
-cat > custom-triplet.cmake << 'EOF'
+cat > $VCPKG_ROOT/triplets/custom-triplet.cmake << 'EOF'
 set(VCPKG_TARGET_ARCHITECTURE x64)
 set(VCPKG_CRT_LINKAGE static)
 set(VCPKG_LIBRARY_LINKAGE static)
 set(VCPKG_CMAKE_CONFIGURE_OPTIONS -DCMAKE_POSITION_INDEPENDENT_CODE=ON)
 EOF
 
-cmake -B build -DCMAKE_TOOLCHAIN_FILE=.../vcpkg.cmake \
+cmake -B build -DCMAKE_TOOLCHAIN_FILE=$VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake \
+  --overlay-triplets=$VCPKG_ROOT/triplets \
   -DVCPKG_TARGET_TRIPLET=custom-triplet
 ```
 

--- a/packages/autoskills/skills-registry/vcpkg/SKILL.md
+++ b/packages/autoskills/skills-registry/vcpkg/SKILL.md
@@ -1,0 +1,178 @@
+---
+name: vcpkg
+description: "Manage C/C++ dependencies with vcpkg. Use when adding libraries, creating vcpkg.json manifests, configuring triplets, or integrating with CMake/MSBuild in C/C++ projects. Covers both manifest and classic modes."
+metadata:
+  version: "1.0"
+  source: "autoskills"
+---
+
+# vcpkg Package Manager
+
+## When to Use
+
+- Adding C/C++ libraries to a project via vcpkg
+- Creating or editing `vcpkg.json` manifest files
+- Configuring custom triplets for cross-compilation
+- Integrating with CMake or MSBuild
+- Resolving dependency conflicts
+- Using binary caching for faster CI builds
+
+## Quick Reference
+
+### Essential Commands
+
+| Task | Command | Notes |
+|------|---------|-------|
+| Install dependencies | `vcpkg install` | Manifest mode |
+| Add a package | `vcpkg add port <name>` | Adds to vcpkg.json |
+| Remove a package | `vcpkg remove <name>` | Removes from manifest |
+| Search packages | `vcpkg search <name>` | Query available ports |
+| Update packages | `vcpkg update` | Show outdated packages |
+| Export package | `vcpkg export <name>` | Create relocatable package |
+| List installed | `vcpkg list` | Show installed packages |
+| Detect triplet | `vcpkg detect` | Auto-detect target triplet |
+
+### vcpkg.json (Manifest)
+
+```json
+{
+  "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
+  "name": "myproject",
+  "version-semver": "1.0.0",
+  "dependencies": [
+    "fmt",
+    "nlohmann-json",
+    "zlib",
+    {
+      "name": "openssl",
+      "features": ["tools"],
+      "platform": "!windows"
+    }
+  ],
+  "builtin-baseline": "c82f74667287d3dc386bce81e44964370c91a289",
+  "overrides": [],
+  "vcpkg-configuration": {
+    "registries": [
+      {
+        "kind": "git",
+        "repository": "https://github.com/microsoft/vcpkg",
+        "baseline": "c82f74667287d3dc386bce81e44964370c91a289"
+      }
+    ]
+  }
+}
+```
+
+## CMake Integration
+
+```cmake
+cmake_minimum_required(VERSION 3.15)
+project(MyApp LANGUAGES CXX)
+
+find_package(fmt CONFIG REQUIRED)
+find_package(nlohmann_json CONFIG REQUIRED)
+
+add_executable(myapp main.cpp)
+target_link_libraries(myapp PRIVATE fmt::fmt nlohmann_json::nlohmann_json)
+```
+
+Build:
+```bash
+cmake -B build -DCMAKE_TOOLCHAIN_FILE=[vcpkg root]/scripts/buildsystems/vcpkg.cmake
+cmake --build build
+```
+
+### Presets (Recommended)
+
+```json
+// CMakePresets.json
+{
+  "version": 3,
+  "configurePresets": [
+    {
+      "name": "vcpkg",
+      "generator": "Ninja",
+      "toolchainFile": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",
+      "binaryDir": "${sourceDir}/build"
+    }
+  ]
+}
+```
+
+## Triplets
+
+```bash
+# Custom triplet for static linking on Linux
+cat > custom-triplet.cmake << 'EOF'
+set(VCPKG_TARGET_ARCHITECTURE x64)
+set(VCPKG_CRT_LINKAGE static)
+set(VCPKG_LIBRARY_LINKAGE static)
+set(VCPKG_CMAKE_CONFIGURE_OPTIONS -DCMAKE_POSITION_INDEPENDENT_CODE=ON)
+EOF
+
+cmake -B build -DCMAKE_TOOLCHAIN_FILE=.../vcpkg.cmake \
+  -DVCPKG_TARGET_TRIPLET=custom-triplet
+```
+
+## Binary Caching
+
+```bash
+# Azure Blob Storage
+export VCPKG_BINARY_SOURCES="clear;x-azblob,https://...;{SAS_TOKEN}"
+
+# GitHub Actions cache
+export VCPKG_BINARY_SOURCES="clear;files,$HOME/.cache/vcpkg/archives"
+
+# NuGet
+export VCPKG_BINARY_SOURCES="clear;nuget,https://nuget.pkg.github.com/..."
+```
+
+## Common Patterns
+
+### Feature selection
+
+```json
+{
+  "dependencies": [
+    {
+      "name": "qtbase",
+      "features": ["gui", "widgets"]
+    }
+  ]
+}
+```
+
+### Platform-specific
+
+```json
+{
+  "dependencies": [
+    {
+      "name": "pthread",
+      "platform": "linux"
+    },
+    {
+      "name": "ws2_32",
+      "platform": "windows"
+    }
+  ]
+}
+```
+
+## Common Gotchas
+
+- Always pin `builtin-baseline` in `vcpkg.json` for reproducible builds
+- Use manifest mode (`vcpkg.json`) for projects, classic mode for global installs
+- Set `VCPKG_ROOT` environment variable
+- Binary caching dramatically speeds up CI — configure it early
+- Use `vcpkg-configuration.json` for custom registries
+- Triplet selection affects static vs dynamic linking
+- Some ports have features that change dependencies — check with `vcpkg search <port> --features`
+
+## Verification Checklist
+
+- [ ] `vcpkg.json` is valid JSON with pinned baseline
+- [ ] `cmake` finds packages via toolchain file
+- [ ] Build links correctly against installed libraries
+- [ ] Binary caching configured for CI
+- [ ] Correct triplet selected for target platform


### PR DESCRIPTION
Adds 9 new skills covering the C/C++/Qt development ecosystem:

- **C** — C11/C17/C23 programming, memory management, Makefiles, POSIX
- **C++** — C++17/20/23, smart pointers, STL, concurrency, templates
- **CMake** — CMakeLists.txt patterns, find_package/FetchContent, CTest
- **Qt** — Qt 6 Widgets, QML, signals/slots, model/view, threading
- **Conan** — Conan 2.x package manager, conanfile recipes, CMake integration
- **vcpkg** — vcpkg manifest mode, triplets, binary caching, CMake integration
- **Meson** — meson.build, WrapDB, cross-compilation, Ninja
- **Google Test** — GTest 1.14+, fixtures, mocking, parameterized tests
- **Doxygen** — Doxyfile config, documentation syntax, CMake integration

### Changes
- 11 files changed, 2,157 insertions
- Each skill has a standalone `SKILL.md` with reference patterns, command tables, best practices, and verification checklists
- Detection entries added to `skills-map.ts` for all 9 technologies
- Registry `index.json` updated with SHA256 hashes and bundle hashes
- Fix commit included: corrected `std::weak_ptr` typo in C++ skill and Meson reference in Google Test checklist

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Nuevas funcionalidades**
  - Se amplían las detecciones automáticas para C/C++, Qt, CMake, Conan, vcpkg, Meson, GoogleTest y Doxygen.
  - Se actualiza el registro de habilidades con nuevas entradas y metadatos asociados para estas tecnologías.

- **Documentación**
  - Se incorporan guías completas para C, C++ moderno, CMake, Conan, vcpkg, Meson, Qt, GoogleTest (GTest/GMock) y Doxygen, con referencias rápidas, patrones, gotchas y checklists de verificación.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->